### PR TITLE
Correct border colour of account header fields from green to purple

### DIFF
--- a/app/javascript/styles/macaron/diff.scss
+++ b/app/javascript/styles/macaron/diff.scss
@@ -1037,6 +1037,10 @@ a.status-card.compact:hover {
   border-bottom: 1px solid lighten($purple, 8%);
 }
 
+.account__header__fields dl {
+  border-bottom: 1px solid lighten($purple, 8%);
+}
+
 @media screen and (max-width: 600px) {
   .public-layout .public-account-header__bar {
     background: $blue;


### PR DESCRIPTION
Minor bugfix for Macaron theme - account header fields (CSS class `account__header__fields dl`) had a border-bottom which was set to green, which looked odd given the purple background. Have now corrected. 