### PR TITLE
Fix inconsistent link underlining

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -324,12 +324,6 @@
       color: $lighter-text-color;
       font-weight: 500;
       text-decoration: underline;
-
-      &:hover,
-      &:active,
-      &:focus {
-        text-decoration: none;
-      }
     }
   }
 
@@ -801,13 +795,9 @@
     }
 
     &.mention {
-      &:hover {
-        text-decoration: none;
-
         span {
           text-decoration: underline;
         }
-      }
     }
 
     .fa {


### PR DESCRIPTION
Fixes issue #7 - have cleaned up styles for regular links as well as mentions/hashtags for consistency.