### PR TITLE
Correct local-only indicator spacing

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1107,6 +1107,7 @@
 .status__action-bar-dropdown {
   height: 23.15px;
   width: 23.15px;
+  margin-right: 18px;
 }
 
 .detailed-status__action-bar-dropdown {


### PR DESCRIPTION
This fixes issue #8. 