### PR TITLE
Corrects syntax for spoiler tags to valid HTML (fixes #10)

### DIFF
--- a/app/javascript/mastodon/components/status_content.js
+++ b/app/javascript/mastodon/components/status_content.js
@@ -223,7 +223,7 @@ export default class StatusContent extends React.PureComponent {
           <p style={{ marginBottom: hidden && status.get('mentions').isEmpty() ? '0px' : null }}>
             <span dangerouslySetInnerHTML={spoilerContent} lang={status.get('language')} />
             {' '}
-            {status.get('activity_pub_type') === 'Article' ? '' : <div><button tabIndex='0' className={`status__content__spoiler-link ${hidden ? 'status__content__spoiler-link--show-more' : 'status__content__spoiler-link--show-less'}`} onClick={this.handleSpoilerClick}>{toggleText}</button></div>}
+            {status.get('activity_pub_type') === 'Article' ? '' : <span class="show_more_button"><button tabIndex='0' className={`status__content__spoiler-link ${hidden ? 'status__content__spoiler-link--show-more' : 'status__content__spoiler-link--show-less'}`} onClick={this.handleSpoilerClick}>{toggleText}</button></span>}
           </p>
 
           {mentionsPlaceholder}

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -6027,3 +6027,14 @@ noscript {
     padding: 0.35rem;
   }
 }
+
+div.status__content,
+div.status__content--with-action,
+div.status__content--with-spoiler {
+  p {
+    span.show_more_button {
+      display: block;
+      margin: 0.25rem 0 0 0;
+    }
+  }
+}


### PR DESCRIPTION
This resolves #10 - I’ve added a class to the span in status_content.js so as not to affect the display style of spans elsewhere in the UI, but otherwise exactly as per the suggestion in the issue.

I also took the liberty of adding a very small margin-top to the span containing the button because it felt a little crammed in to me. 