### PR TITLE
CSS changes for single-column view on smaller screens

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1570,6 +1570,11 @@ a.account__display-name {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+
+  @media screen and (max-width: 1550px) {
+    resize: vertical;
+  }
+
 }
 
 .display-name__html {
@@ -1878,6 +1883,13 @@ a.account__display-name {
         width: 285px;
         pointer-events: auto;
         height: 100%;
+
+        @media screen and (max-width: 1550px) {
+          overflow-y: scroll;
+          overflow-x: hidden;
+          padding-right: 10px;
+        }
+
       }
     }
 
@@ -2261,6 +2273,12 @@ a.account__display-name {
   height: calc(100% - 10px);
   overflow-y: hidden;
 
+  @media screen and (max-width: 1550px) {
+    height: auto;
+    min-height: 100%;
+    overflow-y: visible;
+  }
+
   .navigation-bar {
     padding-top: 20px;
     padding-bottom: 20px;
@@ -2287,6 +2305,11 @@ a.account__display-name {
     background-color: $white;
     border-radius: 4px 4px 0 0;
     flex: 0 1 auto;
+
+    @media screen and (max-width: 1550px) {
+      overflow-y: visible;
+    }
+
   }
 
   .autosuggest-textarea__textarea {


### PR DESCRIPTION
As pointed out by a user on Friend Camp, on smaller (but not mobile-small) screens in single-column layout view, under certain circumstances the input text boxes can become so small they are difficult to use.

Because the left column is fixed in height, a locked response from a public account to a long, cw-ed post can end up collapsing the main textarea to such a small height to accommodate for the other elements in the column that it becomes difficult to see the content.

![prbefore](https://user-images.githubusercontent.com/6143053/65395090-09249e00-dd8e-11e9-82fc-55c54f526407.png)

These CSS changes allow the input boxes to expand exactly as they do in advanced view rather than scrolling when overflow occurs. Because this pushes the footer text off the bottom of the screen, I've also added scrolling to the the left column itself. 

![prafter](https://user-images.githubusercontent.com/6143053/65395136-9f58c400-dd8e-11e9-84ba-8bbb035e73ff.png)

There's an (I believe minor) issue with the scrollbar in the sidebar covering up a few pixels of the search field. Because there's currently no way to identify in the stylesheet itself which template (single-column or advanced) is active, I can't currently figure out a way to fix this without also altering the styling of the search bar in advanced view. I think this is a worthwhile sacrifice for usability (and will think about how to correct it in the longer-term), but appreciate that this might be a bit contentious! 




