### PR TITLE
Stops feed regen task from crashing on exclusive list filtering.

### DIFF
--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -133,7 +133,7 @@ class FeedManager
       break if statuses.empty?
 
       statuses.each do |status|
-        next if filter_from_home?(status, account)
+        next if filter_from_home?(status, account.id)
         added += 1 if add_to_feed(:home, account.id, status, account.user&.aggregates_reblogs?)
       end
 


### PR DESCRIPTION
Fixes #24.

The feed regen task was crashing because an account was being passed to the exclusive list filter where an account ID was expected.

I am unsure how to write an automated test for this so please let me know if there's more I can do. Thanks!