### PR TITLE
Fix resizable display names CSS bug in Safari and Firefox

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1674,11 +1674,6 @@ a.account__display-name {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-
-  @media screen and (max-width: 1550px) {
-    resize: vertical;
-  }
-
 }
 
 .display-name__html {


### PR DESCRIPTION
Reverts a CSS change made in error in PR #22, which caused display names to show up as resizable fields in Safari and Firefox. Sorry! 