### PR TITLE
Adjust custom mascot size on about/more page

### DIFF
--- a/app/javascript/styles/mastodon/about.scss
+++ b/app/javascript/styles/mastodon/about.scss
@@ -585,7 +585,7 @@ $small-breakpoint: 960px;
     bottom: 25px;
 
     img {
-      height: 190px;
+      height: 155px;
       width: auto;
     }
   }


### PR DESCRIPTION
Adjusts the size of the custom mascot on the about/more page so that it will fully fit inside its container and stick to the bottom, as in the advanced web view left-hand sidebar. 