### PR TITLE
Replace mastodon logos in admin area with name of instance

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -46,6 +46,12 @@ $content-width: 840px;
           position: relative;
           bottom: -2px;
         }
+
+        h2 {
+          height: 20px;
+          position: relative;
+          bottom: -2px;
+        }
       }
 
       &__icon {
@@ -68,15 +74,32 @@ $content-width: 840px;
 
     .logo {
       display: block;
-      margin: 40px auto;
-      width: 100px;
+      margin: 60px 0 0 20px;
       height: 100px;
+
+      h2 .brand {
+        color: $primary-text-color;
+        display: block;
+        font-size: 24px;
+        line-height: 28px;
+        font-weight: 400;
+        padding-bottom: 40px;
+        border-bottom: 1px solid lighten($ui-base-color, 8%);
+      }
+
     }
 
     @media screen and (max-width: $no-columns-breakpoint) {
       & > a:first-child {
         display: none;
       }
+
+      .logo,
+      .logo h2,
+      .logo h2 .brand {
+        display: none;
+      }
+
     }
 
     ul {

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -6,13 +6,16 @@
     .sidebar-wrapper
       .sidebar-wrapper__inner
         .sidebar
-          = link_to root_path do
-            = image_pack_tag 'logo.svg', class: 'logo', alt: 'Mastodon'
+          .logo
+            %h2
+              = link_to root_url, class: 'brand' do
+                = site_title
 
           .sidebar__toggle
             .sidebar__toggle__logo
-              = link_to root_path do
-                = svg_logo_full
+              %h2
+                = link_to root_path, class: 'brand' do
+                  = site_title
 
             = link_to '#', class: 'sidebar__toggle__icon' do
               = fa_icon 'bars'


### PR DESCRIPTION
One I missed in #19. Removes logos in the admin area and replaces them with the name of the instance.