### PR TITLE
Make fields in public profile expand on click

### DIFF
--- a/app/javascript/packs/public.js
+++ b/app/javascript/packs/public.js
@@ -257,6 +257,42 @@ function main() {
       target.style.display = 'block';
     }
   });
+
+  delegate(document, '.account__header__fields dl', 'click', ( { target } ) => {
+    const row = target.parentNode;
+
+    if (row.children[0].style.maxHeight === '48px' || row.children[1].style.maxHeight === '48px') {
+        row.children[0].style.maxHeight = 'none';
+        row.children[1].style.maxHeight = 'none';
+        row.children[0].style.whiteSpace = 'normal';
+        row.children[1].style.whiteSpace = 'normal';
+    } else {
+        row.children[0].style.maxHeight = '48px';
+        row.children[1].style.maxHeight = '48px';
+        row.children[0].style.whiteSpace = 'nowrap';
+        row.children[1].style.whiteSpace = 'nowrap';
+    }
+  });
+
+  ready(() => {
+
+    const dls = document.querySelectorAll('.account__header__fields dl');
+    console.log(dls);
+
+    for (let i = 0; i < dls.length; i++) {
+
+      if(dls[i].children[0].offsetWidth < dls[i].children[0].scrollWidth ||
+         dls[i].children[1].offsetWidth < dls[i].children[1].scrollWidth) {
+           dls[i].children[0].style.maxHeight = '48px';
+           dls[i].children[1].style.maxHeight = '48px';
+           dls[i].children[0].style.whiteSpace = 'nowrap';
+           dls[i].children[1].style.whiteSpace = 'nowrap';
+           dls[i].style.cursor = 'pointer';
+         }
+
+    }
+
+  });
 }
 
 loadPolyfills().then(main).catch(error => {

--- a/app/javascript/styles/mastodon/accounts.scss
+++ b/app/javascript/styles/mastodon/accounts.scss
@@ -236,6 +236,7 @@
   dl {
     display: flex;
     border-bottom: 1px solid lighten($ui-base-color, 12%);
+    align-items: stretch;
   }
 
   dt,


### PR DESCRIPTION
At the request of a friend camp user, I've written some JS to make the boxes on public profile expand to show the full text on click/tap. 

The only way to view this text in vanilla Mastodon web view is mousing over to see it as an alt title label - there is currently no way to view it on iOS touch devices without using a client (not sure about Android). This alternative should work on any device. Cursor users will see a pointer cursor on hover, which will only show up if text is overflowed and partially hidden. 

This works great on public profiles, but I am having trouble implementing it in the main web view, I believe because of the order in which webpack loads things, so would appreciate any help with this you can offer. The one thing I have not yet tried is rewriting and mounting the script as a React component but I'd like to avoid this if possible since it seems like overkill for something that is both extremely functionally simple and not reused across multiple React contexts. 