### PR TITLE
Remove DB dependancy from assets:precompile

### DIFF
--- a/app/views/layouts/error.html.haml
+++ b/app/views/layouts/error.html.haml
@@ -13,6 +13,6 @@
       .dialog__illustration
         %h1
           = link_to root_url, class: 'brand' do
-            = site_title
+            = Setting.default_settings['site_title']
       .dialog__message
         %h1= yield :content


### PR DESCRIPTION
When running `bundle exec rails assets:precompile` inside docker build, with `site_title` it requires a DB connection, where as `Setting.default_settings['site_title']` doesn't.

Running a docker build without this commit, the following error is reported: 
```
...
[build-hometown:5785] ** Execute assets:generate_static_pages
[build-hometown:5786] rails aborted!
[build-hometown:5787] ActionView::Template::Error: could not connect to server: Connection refused
[build-hometown:5788] 	Is the server running on host "localhost" (127.0.0.1) and accepting
[build-hometown:5789] 	TCP/IP connections on port 5432?
[build-hometown:5790] could not connect to server: Cannot assign requested address
[build-hometown:5791] 	Is the server running on host "localhost" (::1) and accepting
[build-hometown:5792] 	TCP/IP connections on port 5432?
[build-hometown:5793] /opt/mastodon/vendor/bundle/ruby/2.6.0/gems/pg-1.1.4/lib/pg.rb:56:in `initialize'
[build-hometown:5794] /opt/mastodon/vendor/bundle/ruby/2.6.0/gems/pg-1.1.4/lib/pg.rb:56:in `new'
[build-hometown:5795] /opt/mastodon/vendor/bundle/ruby/2.6.0/gems/pg-1.1.4/lib/pg.rb:56:in `connect'
...
```
I can provide the full trace logs if needed.

`Setting.default_settings['site_title']` is used elsewhere in this file, so I assume here is fine as well.