### PR TITLE
revert change that made scrollbars visible in sidebars

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2056,13 +2056,6 @@ a.account__display-name {
         width: 285px;
         pointer-events: auto;
         height: 100%;
-
-        @media screen and (max-width: 1550px) {
-          overflow-y: scroll;
-          overflow-x: hidden;
-          padding-right: 10px;
-        }
-
       }
     }
 
@@ -2492,12 +2485,6 @@ a.account__display-name {
   height: calc(100% - 10px);
   overflow-y: hidden;
 
-  @media screen and (max-width: 1550px) {
-    height: auto;
-    min-height: 100%;
-    overflow-y: visible;
-  }
-
   .navigation-bar {
     padding-top: 20px;
     padding-bottom: 20px;
@@ -2524,11 +2511,6 @@ a.account__display-name {
     background-color: $white;
     border-radius: 4px 4px 0 0;
     flex: 0 1 auto;
-
-    @media screen and (max-width: 1550px) {
-      overflow-y: visible;
-    }
-
   }
 
   .autosuggest-textarea__textarea {


### PR DESCRIPTION
While creating a custom theme for our instance running hometown, I noticed a little bug. Hometown has a change in the main `components.css` file that breaks the sidebar layout and triggers scrollbars to be shown.

In this pull request I have reverted the commit 1e1eed84bd54d899fe785271e2da515a77de2996, since this solved the problem for me. There is probably a better solution than just reverting but my frontend skills are very limited. I mostly wanted to highlight the problem for you :)