### PR TITLE
use the hometown logo on public pages

### DIFF
--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -99,10 +99,6 @@ module AccountsHelper
   end
 
   def svg_logo
-    content_tag(:svg, tag(:use, 'xlink:href' => '#mastodon-svg-logo'), 'viewBox' => '0 0 216.4144 232.00976')
-  end
-
-  def svg_logo_full
-    content_tag(:svg, tag(:use, 'xlink:href' => '#mastodon-svg-logo-full'), 'viewBox' => '0 0 713.35878 175.8678')
+    content_tag(:svg, tag(:use, 'xlink:href' => '#hometownlogo'), 'viewBox' => '0 0 216.4144 232.00976')
   end
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -38,4 +38,3 @@
 
     .logo-resources
       = render file: Rails.root.join('app', 'javascript', 'images', 'hometown.svg')
-      = render file: Rails.root.join('app', 'javascript', 'images', 'logo_full.svg')


### PR DESCRIPTION
The follow button on public profiles and the footer "What is hometown?" is missing the hometown logo. Instead there is currently an empty space. This makes it use the hometown logo instead.

One small issue: The hometown SVG logo is smaller than the clip box, so the logo will appear smaller on the website than the mastodon logo used to. I'm not sure how to fix this, other than remaking the hometown.svg. That is beyond my knowledge :)