### PR TITLE
change emoji button to more neutral emoji

### DIFF
--- a/app/javascript/mastodon/features/compose/components/emoji_picker_dropdown.js
+++ b/app/javascript/mastodon/features/compose/components/emoji_picker_dropdown.js
@@ -361,7 +361,7 @@ class EmojiPickerDropdown extends React.PureComponent {
           <img
             className={classNames('emojione', { 'pulse-loading': active && loading })}
             alt='🙂'
-            src={`${assetHost}/emoji/1f602.svg`}
+            src={`${assetHost}/emoji/1f600.svg`}
           />
         </div>
 


### PR DESCRIPTION
After seeing this status I realised a lot of people actually don't like the emoji used as the button for the emoji picker. 
https://elekk.xyz/@mint/103850474823492409

Actually I agree. Lets change it to a more neutral emoji. With this change it uses the default smiley face: 😀 