### PR TITLE
do not show local_only statuses in "Federated" feed

### DIFF
--- a/app/controllers/api/v1/timelines/public_controller.rb
+++ b/app/controllers/api/v1/timelines/public_controller.rb
@@ -39,7 +39,9 @@ class Api::V1::Timelines::PublicController < Api::BaseController
   end
 
   def public_timeline_statuses
-    Status.as_public_timeline(current_account, truthy_param?(:remote) ? :remote : truthy_param?(:local))
+    query = Status.as_public_timeline(current_account, truthy_param?(:remote) ? :remote : truthy_param?(:local))
+    query = query.without_local_only unless truthy_param?(:local)
+    query
   end
 
   def insert_pagination_headers


### PR DESCRIPTION
Currently the federated feed also includes posts marked as "local only". This can be quite confusing for new users since one would expect to only find federated posts in the "Federated" feed.

This code is not super pretty as I'm a ruby beginner. But it works. In this code we also see the confusing naming collisions of "local_only" and "local".

local: true on statuses that originate from the current instance
local_only: true for statuses that never federate and stay local only