### PR TITLE
Scrollbars shown even when not needed

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2089,13 +2089,6 @@ a.account__display-name {
         width: 285px;
         pointer-events: auto;
         height: 100%;
-
-        @media screen and (max-width: 1550px) {
-          overflow-y: scroll;
-          overflow-x: hidden;
-          padding-right: 10px;
-        }
-
       }
     }
 
@@ -2536,12 +2529,6 @@ a.account__display-name {
   height: calc(100% - 10px);
   overflow-y: hidden;
 
-  @media screen and (max-width: 1550px) {
-    height: auto;
-    min-height: calc(100% - 10px);
-    overflow-y: visible;
-  }
-
   .navigation-bar {
     padding-top: 20px;
     padding-bottom: 20px;
@@ -2568,11 +2555,6 @@ a.account__display-name {
     background-color: $white;
     border-radius: 4px 4px 0 0;
     flex: 0 1 auto;
-
-    @media screen and (max-width: 1550px) {
-      overflow-y: visible;
-    }
-
   }
 
   .autosuggest-textarea__textarea {


### PR DESCRIPTION
I previously created a pull request for this scrollbar issue (https://github.com/hometown-fork/hometown/pull/52). That was merged, but then reverted because you couldn't see the issue anymore I think.

Now while rebasing on your latest release (1.5.0+3.3.0) this issue still persist. This is a CSS layout change that Hometown introduced and it breaks how the scrollbars are shown. Let me explain with two screenshots.

This is a screenshot from my local dev on the latest Hometown release. The orange scroll bars are shown even though the view is large enough to show all content in the sidebars. This happens in all themes. 
![Screenshot from 2021-05-03 23-36-48](https://user-images.githubusercontent.com/219730/117722406-4cd94f00-b1e1-11eb-9ddc-c03df3f2f16c.png)

This is a screenshot with the commit in this pull request applied. Scroll bars are now correctly hidden when the view is large enough.
![Screenshot from 2021-05-03 23-37-56](https://user-images.githubusercontent.com/219730/117722450-5e225b80-b1e1-11eb-899a-22dc2f74e776.png)

I'm not sure exactly what breaks here, all I know is that applying this fix solves it, and I have not noticed any other negative effects.
