### PR TITLE
show about pages also in limited federation mode

### DIFF
--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -5,7 +5,6 @@ class AboutController < ApplicationController
 
   layout 'public'
 
-  before_action :require_open_federation!, only: [:show, :more]
   before_action :set_body_classes, only: :show
   before_action :set_instance_presenter
   before_action :set_expires_in, only: [:more, :terms]
@@ -34,10 +33,6 @@ class AboutController < ApplicationController
   helper_method :new_user
 
   private
-
-  def require_open_federation!
-    not_found if whitelist_mode?
-  end
 
   def display_blocks?
     Setting.show_domain_blocks == 'all' || (Setting.show_domain_blocks == 'users' && user_signed_in?)

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -41,7 +41,7 @@ class HomeController < ApplicationController
   end
 
   def default_redirect_path
-    if request.path.start_with?('/web') || whitelist_mode?
+    if request.path.start_with?('/web')
       new_user_session_path
     elsif single_user_mode?
       short_account_path(Account.local.without_suspended.where('id > 0').first)

--- a/app/views/admin/settings/edit.html.haml
+++ b/app/views/admin/settings/edit.html.haml
@@ -77,15 +77,17 @@
     .fields-group
       = f.input :preview_sensitive_media, as: :boolean, wrapper: :with_label, label: t('admin.settings.preview_sensitive_media.title'), hint: t('admin.settings.preview_sensitive_media.desc_html')
 
-    .fields-group
-      = f.input :profile_directory, as: :boolean, wrapper: :with_label, label: t('admin.settings.profile_directory.title'), hint: t('admin.settings.profile_directory.desc_html')
+  .fields-group
+    = f.input :profile_directory, as: :boolean, wrapper: :with_label, label: t('admin.settings.profile_directory.title'), hint: t('admin.settings.profile_directory.desc_html')
 
+  - unless whitelist_mode?
     .fields-group
       = f.input :trends, as: :boolean, wrapper: :with_label, label: t('admin.settings.trends.title'), hint: t('admin.settings.trends.desc_html')
 
     .fields-group
       = f.input :trendable_by_default, as: :boolean, wrapper: :with_label, label: t('admin.settings.trendable_by_default.title'), hint: t('admin.settings.trendable_by_default.desc_html')
 
+  - unless whitelist_mode?
     .fields-group
       = f.input :noindex, as: :boolean, wrapper: :with_label, label: t('admin.settings.default_noindex.title'), hint: t('admin.settings.default_noindex.desc_html')
 
@@ -101,7 +103,7 @@
       = f.input :show_domain_blocks_rationale, wrapper: :with_label, collection: %i(disabled users all), label: t('admin.settings.domain_blocks_rationale.title'), label_method: lambda { |value| t("admin.settings.domain_blocks.#{value}") }, include_blank: false, collection_wrapper_tag: 'ul', item_wrapper_tag: 'li'
 
   .fields-group
-    = f.input :site_extended_description, wrapper: :with_block_label, as: :text, label: t('admin.settings.site_description_extended.title'), hint: t('admin.settings.site_description_extended.desc_html'), input_html: { rows: 8 } unless whitelist_mode?
+    = f.input :site_extended_description, wrapper: :with_block_label, as: :text, label: t('admin.settings.site_description_extended.title'), hint: t('admin.settings.site_description_extended.desc_html'), input_html: { rows: 8 }
     = f.input :closed_registrations_message, as: :text, wrapper: :with_block_label, label: t('admin.settings.registrations.closed_message.title'), hint: t('admin.settings.registrations.closed_message.desc_html'), input_html: { rows: 8 }
     = f.input :site_terms, wrapper: :with_block_label, as: :text, label: t('admin.settings.site_terms.title'), hint: t('admin.settings.site_terms.desc_html'), input_html: { rows: 8 }
     = f.input :custom_css, wrapper: :with_block_label, as: :text, input_html: { rows: 8 }, label: t('admin.settings.custom_css.title'), hint: t('admin.settings.custom_css.desc_html')

--- a/app/views/auth/shared/_links.html.haml
+++ b/app/views/auth/shared/_links.html.haml
@@ -5,7 +5,7 @@
     - if controller_name != 'sessions'
       %li= link_to t('auth.login'), new_user_session_path
 
-    - if controller_name != 'registrations'
+    - if controller_name != 'registrations' && !whitelist_mode?
       %li= link_to t('auth.register'), available_sign_up_path
 
     - if controller_name != 'passwords' && controller_name != 'registrations'

--- a/app/views/layouts/public.html.haml
+++ b/app/views/layouts/public.html.haml
@@ -11,9 +11,10 @@
             = link_to root_url, class: 'brand' do
               = site_title
 
+            = link_to t('about.about_this'), about_more_path, class: 'nav-link optional'
+
             - unless whitelist_mode?
               = link_to t('directories.directory'), explore_path, class: 'nav-link optional' if Setting.profile_directory
-              = link_to t('about.about_this'), about_more_path, class: 'nav-link optional'
               = link_to t('about.apps'), 'https://joinmastodon.org/apps', class: 'nav-link optional'
 
           .nav-center


### PR DESCRIPTION
We are running queer.haus in "limited federation mode" so we work with an allow list instead of a block list for federation. This mode hides all public pages by default, which makes it difficult to explain who we are to curious visitors.

This changes that so the about pages are still visible even in limited federation mode. All other public pages like profiles and posts are still hidden. I think this might be valuable also for other hometown instances.

More info on limited federation mode: https://docs.joinmastodon.org/admin/config/#limited_federation_mode

This code change initially comes from https://awoo.space (https://github.com/noiob/awoospace)