### PR TITLE
Fairy Floss color tweaks

### DIFF
--- a/app/javascript/styles/fairy-floss/diff.scss
+++ b/app/javascript/styles/fairy-floss/diff.scss
@@ -548,3 +548,7 @@ a.mention, .notification__message .fa {
 .video-player__buttons button {
   color: $ui-primary-color;
 }
+
+.tabs-bar__wrapper {
+  background: $purple1;
+}

--- a/app/javascript/styles/fairy-floss/diff.scss
+++ b/app/javascript/styles/fairy-floss/diff.scss
@@ -230,6 +230,12 @@ html {
   border-bottom: 1px solid lighten($purple2, 8%);
 }
 
+.status.status-direct {
+  background: $purple1;
+  border-right: 1px solid $purple2;
+  border-left: 1px solid $purple2;
+}
+
 .detailed-status, .detailed-status__action-bar {
   background: $purplescrollbar;
 }


### PR DESCRIPTION
This PR contains two small color tweaks:
- Changes the background color of direct messages in the main timeline to differentiate them from other status updates, similar to how the Macaron theme does this.
- Fixes a dark background color above the timeline to match the main page background.