### PR TITLE
Fix exclusive list changing to regular list after rename

### DIFF
--- a/app/javascript/mastodon/reducers/list_editor.js
+++ b/app/javascript/mastodon/reducers/list_editor.js
@@ -25,6 +25,7 @@ const initialState = ImmutableMap({
   isSubmitting: false,
   isChanged: false,
   title: '',
+  isExclusive: false,
 
   accounts: ImmutableMap({
     items: ImmutableList(),
@@ -46,6 +47,7 @@ export default function listEditorReducer(state = initialState, action) {
     return state.withMutations(map => {
       map.set('listId', action.list.get('id'));
       map.set('title', action.list.get('title'));
+      map.set('isExclusive', action.list.get('is_exclusive'));
       map.set('isSubmitting', false);
     });
   case LIST_EDITOR_TITLE_CHANGE:


### PR DESCRIPTION
This fixes #741, where renaming an exclusive list resets the "exclusive?" setting.

Cause of the bug: `listEditorReducer` wasn't setting an initial state for `isExclusive`, so it would be set to `undefined` when submitting the form.