### PR TITLE
Gemfile: remove extraneous fields

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -851,9 +851,3 @@ DEPENDENCIES
   webpacker (~> 5.4)
   webpush (~> 0.3)
   xorcist (~> 1.1)
-
-RUBY VERSION
-   ruby 2.6.5p114
-
-BUNDLED WITH
-   1.17.2


### PR DESCRIPTION
These fields aren't in the [upstream Gemfile.lock](https://github.com/mastodon/mastodon/blob/main/Gemfile.lock). The bundler version in particular will stop you from bundling with a newer version by default, and Bundler 1.17 isn't included with the Ruby version required by the latest Mastodons.