### PR TITLE
Updates the article formatter to strip unsafe HTML

### DIFF
--- a/app/helpers/formatting_helper.rb
+++ b/app/helpers/formatting_helper.rb
@@ -22,6 +22,10 @@ module FormattingHelper
     html_aware_format(account.note, account.local?)
   end
 
+  def article_format(text)
+    html_aware_format(text, false)
+  end
+
   def account_field_value_format(field, with_rel_me: true)
     html_aware_format(field.value, field.account.local?, with_rel_me: with_rel_me, with_domains: true, multiline: false)
   end

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -423,8 +423,8 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   def text_from_content
     return converted_text if converted_object_type?
 
-    return Formatter.instance.format_article(@object['content']) if @object['content'].present? && @object['type'] == 'Article'
-    
+    return article_format(@object['content']) if @object['content'].present? && @object['type'] == 'Article'
+
     return @status_parser.text || ''
   end
 

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -171,7 +171,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
       end
 
       media_attachment = MediaAttachment.create(account: @account, remote_url: src, description: handler.alts[src], focus: nil)
-      media_attachment.file_remote_url = src
+      media_attachment.download_file!
       media_attachment.save
       if unsupported_media_type?(media_attachment.file.content_type)
         @object['content'].gsub!(src, '')


### PR DESCRIPTION
Looks like the formatter was refactored at some point, potentially breaking Article support?

This addresses https://github.com/hometown-fork/hometown/issues/1183 and I was able to successfully interact with Article objects after applying this patch to my personal instance. 