### PR TITLE
Hide local-only posts from public tag view

### DIFF
--- a/app/controllers/api/v1/timelines/tag_controller.rb
+++ b/app/controllers/api/v1/timelines/tag_controller.rb
@@ -41,7 +41,8 @@ class Api::V1::Timelines::TagController < Api::BaseController
       none: params[:none],
       local: truthy_param?(:local),
       remote: truthy_param?(:remote),
-      only_media: truthy_param?(:only_media)
+      only_media: truthy_param?(:only_media),
+      without_local_only: !current_user
     )
   end
 

--- a/app/models/public_feed.rb
+++ b/app/models/public_feed.rb
@@ -51,6 +51,10 @@ class PublicFeed
     options[:local]
   end
 
+  def without_local_only?
+    options[:without_local_only]
+  end
+
   def remote_only?
     options[:remote]
   end
@@ -73,6 +77,10 @@ class PublicFeed
 
   def remote_only_scope
     Status.remote
+  end
+
+  def without_local_only_scope
+    Status.without_local_only
   end
 
   def without_replies_scope

--- a/app/models/tag_feed.rb
+++ b/app/models/tag_feed.rb
@@ -32,6 +32,7 @@ class TagFeed < PublicFeed
     scope.merge!(remote_only_scope) if remote_only?
     scope.merge!(account_filters_scope) if account?
     scope.merge!(media_only_scope) if media_only?
+    scope.merge!(without_local_only_scope) if without_local_only?
 
     scope.cache_ids.to_a_paginated_by_id(limit, max_id: max_id, since_id: since_id, min_id: min_id)
   end

--- a/spec/models/tag_feed_spec.rb
+++ b/spec/models/tag_feed_spec.rb
@@ -57,6 +57,12 @@ describe TagFeed, type: :service do
       expect(results).to_not include status1
     end
 
+    it 'excludes local-only posts when specified' do
+      status1.update(local_only: true)
+      results = described_class.new(tag1, nil, any: [tag2.name], without_local_only: true).get(20)
+      expect(results).to_not include status1
+    end
+
     it 'allows replies to be included' do
       original = Fabricate(:status)
       status = Fabricate(:status, tags: [tag1], in_reply_to_id: original.id)


### PR DESCRIPTION
Adds support for applying the `without_local_only` scope in `PublicFeed`, then takes advantage of that option in `TagController` when there is no `current_user`. A logged-in user viewing a tag page will be able to see local-only posts with that tag; a logged-out user viewing that same page will only see public, federated posts.

I'm not so familiar with all the different code paths here, so let me know if there's some other wiggly way of getting to this page that would not hit this updated logic—it's possible I need to move it somewhere more general, or duplicate it to another controller. Also, I added just one test at the lowest level because the coverage on the other touched files looked to be more general, but I can add more tests if desired.

Thank you for your consideration!

Fixes #1180