### PR TITLE
Support changing list replies policy from web UI

### DIFF
--- a/app/javascript/mastodon/actions/lists.js
+++ b/app/javascript/mastodon/actions/lists.js
@@ -160,7 +160,7 @@ export const createListFail = error => ({
 export const updateList = (id, title, shouldReset, isExclusive, replies_policy) => (dispatch, getState) => {
   dispatch(updateListRequest(id));
 
-  api(getState).put(`/api/v1/lists/${id}`, { title, replies_policy, is_exclusive: !!isExclusive }).then(({ data }) => {
+  api(getState).put(`/api/v1/lists/${id}`, { title, replies_policy, is_exclusive: typeof isExclusive === 'undefined' ? undefined : !!isExclusive }).then(({ data }) => {
     dispatch(updateListSuccess(data));
 
     if (shouldReset) {

--- a/app/javascript/mastodon/features/list_timeline/index.js
+++ b/app/javascript/mastodon/features/list_timeline/index.js
@@ -137,7 +137,7 @@ class ListTimeline extends React.PureComponent {
   handleRepliesPolicyChange = ({ target }) => {
     const { dispatch } = this.props;
     const { id } = this.props.params;
-    dispatch(updateList(id, undefined, false, target.value));
+    dispatch(updateList(id, undefined, false, undefined, target.value));
   }
 
   render () {


### PR DESCRIPTION
Modifies the arguments sent to the `updateList` function to properly set the new `replies_policy` value, as well as allowing for an `undefined` value for the `isExclusive` setting, which will result in no new value being sent to the API for that attribute—that is, when changing the replies policy, the unrelated exclusive toggle will be left unchanged.

Fixes #1191