### PR TITLE
Swap version numbers and add identifier

### DIFF
--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -5,15 +5,15 @@ module Mastodon
     module_function
 
     def major
-      1
+      3
     end
 
     def minor
-      0
+      5
     end
 
     def patch
-      7
+      5
     end
 
     def flags
@@ -21,7 +21,7 @@ module Mastodon
     end
 
     def suffix
-      '+3.5.5'
+      '+hometown-1.0.8'
     end
 
     def to_a


### PR DESCRIPTION
For better compatibility with third party apps and to be more in line with what other fediverse software does (including other Mastodon forks), I am changing the semver version to reflect the synchronized Mastodon version, and making the Hometown version part of the build metadata after the '+' sign. I am also adding a 'hometown' identifier to the build metadata.

Fixes #1213