### PR TITLE
Add option to keep local-only posts on auto-delete

### DIFF
--- a/app/controllers/statuses_cleanup_controller.rb
+++ b/app/controllers/statuses_cleanup_controller.rb
@@ -26,7 +26,7 @@ class StatusesCleanupController < ApplicationController
   end
 
   def resource_params
-    params.require(:account_statuses_cleanup_policy).permit(:enabled, :min_status_age, :keep_direct, :keep_pinned, :keep_polls, :keep_media, :keep_self_fav, :keep_self_bookmark, :min_favs, :min_reblogs)
+    params.require(:account_statuses_cleanup_policy).permit(:enabled, :min_status_age, :keep_direct, :keep_pinned, :keep_polls, :keep_media, :keep_self_fav, :keep_local, :keep_self_bookmark, :min_favs, :min_reblogs)
   end
 
   def set_body_classes

--- a/app/models/account_statuses_cleanup_policy.rb
+++ b/app/models/account_statuses_cleanup_policy.rb
@@ -14,6 +14,7 @@
 #  keep_media         :boolean          default(FALSE), not null
 #  keep_self_fav      :boolean          default(TRUE), not null
 #  keep_self_bookmark :boolean          default(TRUE), not null
+#  keep_local         :boolean          default(TRUE), not null
 #  min_favs           :integer
 #  min_reblogs        :integer
 #  created_at         :datetime         not null
@@ -66,6 +67,7 @@ class AccountStatusesCleanupPolicy < ApplicationRecord
     scope.merge!(without_poll_scope) if keep_polls?
     scope.merge!(without_media_scope) if keep_media?
     scope.merge!(without_self_fav_scope) if keep_self_fav?
+    scope.merge!(without_local_scope) if keep_local?
     scope.merge!(without_self_bookmark_scope) if keep_self_bookmark?
 
     scope.reorder(id: :asc).limit(limit)
@@ -141,6 +143,10 @@ class AccountStatusesCleanupPolicy < ApplicationRecord
     # has switched to snowflake IDs significantly over 2 years ago anyway.
     max_id = [max_id, Mastodon::Snowflake.id_at(min_status_age.seconds.ago, with_random: false)].compact.min
     Status.where(Status.arel_table[:id].lteq(max_id))
+  end
+
+  def without_local_scope
+    Status.where(local_only: false)
   end
 
   def without_self_fav_scope

--- a/app/views/statuses_cleanup/show.html.haml
+++ b/app/views/statuses_cleanup/show.html.haml
@@ -34,6 +34,10 @@
     .fields-row__column.fields-row__column-6.fields-group
       = f.input :keep_media, wrapper: :with_label, label: t('statuses_cleanup.keep_media'), hint: t('statuses_cleanup.keep_media_hint')
 
+  .fields-row
+    .fields-row__column.fields-row__column-6.fields-group
+      = f.input :keep_local, wrapper: :with_label, label: t('statuses_cleanup.keep_local'), hint: t('statuses_cleanup.keep_local_hint')
+
   %h4= t('statuses_cleanup.interaction_exceptions')
 
   .fields-row

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1494,6 +1494,8 @@ en:
     interaction_exceptions_explanation: Note that there is no guarantee for posts to be deleted if they go below the favourite or boost threshold after having once gone over them.
     keep_direct: Keep direct messages
     keep_direct_hint: Doesn't delete any of your direct messages
+    keep_local: Keep local-only messages
+    keep_local_hint: Doesn't delete any of your local-only posts
     keep_media: Keep posts with media attachments
     keep_media_hint: Doesn't delete any of your posts that have media attachments
     keep_pinned: Keep pinned posts

--- a/db/migrate/20221202035831_add_keep_local_to_account_statuses_cleanup_policies.rb
+++ b/db/migrate/20221202035831_add_keep_local_to_account_statuses_cleanup_policies.rb
@@ -1,0 +1,5 @@
+class AddKeepLocalToAccountStatusesCleanupPolicies < ActiveRecord::Migration[6.1]
+  def change
+    add_column :account_statuses_cleanup_policies, :keep_local, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_29_101850) do
+ActiveRecord::Schema.define(version: 2022_12_02_035831) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -116,6 +116,7 @@ ActiveRecord::Schema.define(version: 2022_04_29_101850) do
     t.integer "min_reblogs"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "keep_local", default: true, null: false
     t.index ["account_id"], name: "index_account_statuses_cleanup_policies_on_account_id"
   end
 


### PR DESCRIPTION
This adds a `keep_local` column to the `account_statuses_cleanup_policy` table in the database. There is a new checkbox in the preferences for automatic post deletion, and when calculating which statuses to delete there is now a filter for `without_local_scope`.

Fixes #1187 