### PR TITLE
Make the "media gallery" not show up on Articles

### DIFF
--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -498,7 +498,7 @@ class Status extends ImmutablePureComponent {
 
             <StatusContent status={status} onClick={this.handleClick} expanded={!status.get('hidden')} showThread={showThread} onExpandedToggle={this.handleExpandedToggle} collapsable onCollapsedToggle={this.handleCollapsedToggle} />
 
-            {media}
+            {status.get('activity_pub_type') === 'Article' ? null : media}
 
             <StatusActionBar scrollKey={scrollKey} status={status} account={account} {...other} />
           </div>

--- a/app/javascript/mastodon/features/status/components/detailed_status.js
+++ b/app/javascript/mastodon/features/status/components/detailed_status.js
@@ -264,7 +264,7 @@ class DetailedStatus extends ImmutablePureComponent {
 
           <StatusContent status={status} expanded={status.get('activity_pub_type') === 'Article' || !status.get('hidden')} onExpandedToggle={this.handleExpandedToggle} />
 
-          {media}
+          {status.get('activity_pub_type') === 'Article' ? null : media}
 
           <div className='detailed-status__meta'>
             <a className='detailed-status__datetime' href={status.get('url')} target='_blank' rel='noopener noreferrer'>


### PR DESCRIPTION
When we fetch Articles, we render images inline as intended by the Article. There is no need for a Media Gallery item.

Fixes #1183 