### PR TITLE
Expose the "default_federation" preference on the preferences API

### DIFF
--- a/app/serializers/rest/preferences_serializer.rb
+++ b/app/serializers/rest/preferences_serializer.rb
@@ -4,6 +4,7 @@ class REST::PreferencesSerializer < ActiveModel::Serializer
   attribute :posting_default_privacy, key: 'posting:default:visibility'
   attribute :posting_default_sensitive, key: 'posting:default:sensitive'
   attribute :posting_default_language, key: 'posting:default:language'
+  attribute :posting_default_federation, key: 'posting:default:federation'
 
   attribute :reading_default_sensitive_media, key: 'reading:expand:media'
   attribute :reading_default_sensitive_text, key: 'reading:expand:spoilers'
@@ -26,5 +27,9 @@ class REST::PreferencesSerializer < ActiveModel::Serializer
 
   def reading_default_sensitive_text
     object.user.setting_expand_spoilers
+  end
+
+  def posting_default_federation
+    object.user.setting_default_federation
   end
 end

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -157,7 +157,7 @@ en:
         setting_auto_play_gif: Auto-play animated GIFs
         setting_boost_modal: Show confirmation dialog before boosting
         setting_crop_images: Crop images in non-expanded posts to 16x9
-        setting_default_federation: Allow my posts to reach other instances by default
+        setting_default_federation: Allow my posts to reach other servers by default
         setting_default_language: Posting language
         setting_default_privacy: Posting privacy
         setting_default_sensitive: Always mark media as sensitive


### PR DESCRIPTION
Now when you make a call to `api/v1/preferences` you get a `posting:default:federation` response, which is `true` if the user's posts federate by default, and `false` if the user's posts are local-only by default.

Fixes #1219 