### PR TITLE
Adding a `norss` user preference

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -45,6 +45,11 @@ class AccountsController < ApplicationController
       format.rss do
         expires_in 1.minute, public: true
 
+        if @account&.user&.setting_norss == true
+          @statuses = []
+          next
+        end
+
         limit     = params[:limit].present? ? [params[:limit].to_i, PAGE_SIZE_MAX].min : PAGE_SIZE
         @statuses = filtered_statuses.without_reblogs.without_local_only.limit(limit)
         @statuses = cache_collection(@statuses, Status)

--- a/app/controllers/settings/preferences_controller.rb
+++ b/app/controllers/settings/preferences_controller.rb
@@ -47,6 +47,7 @@ class Settings::PreferencesController < Settings::BaseController
       :setting_disable_swiping,
       :setting_system_font_ui,
       :setting_noindex,
+      :setting_norss,
       :setting_theme,
       :setting_aggregate_reblogs,
       :setting_show_application,

--- a/app/lib/settings/scoped_settings.rb
+++ b/app/lib/settings/scoped_settings.rb
@@ -5,6 +5,7 @@ module Settings
     DEFAULTING_TO_UNSCOPED = %w(
       theme
       noindex
+      norss
     ).freeze
 
     def initialize(object)

--- a/app/lib/user_settings_decorator.rb
+++ b/app/lib/user_settings_decorator.rb
@@ -31,6 +31,7 @@ class UserSettingsDecorator
     user.settings['disable_swiping']     = disable_swiping_preference if change?('setting_disable_swiping')
     user.settings['system_font_ui']      = system_font_ui_preference if change?('setting_system_font_ui')
     user.settings['noindex']             = noindex_preference if change?('setting_noindex')
+    user.settings['norss']               = norss_preference if change?('setting_norss')
     user.settings['theme']               = theme_preference if change?('setting_theme')
     user.settings['aggregate_reblogs']   = aggregate_reblogs_preference if change?('setting_aggregate_reblogs')
     user.settings['show_application']    = show_application_preference if change?('setting_show_application')
@@ -100,6 +101,10 @@ class UserSettingsDecorator
 
   def noindex_preference
     boolean_cast_setting 'setting_noindex'
+  end
+
+  def norss_preference
+    boolean_cast_setting 'setting_norss'
   end
 
   def show_application_preference

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -33,6 +33,7 @@ class Form::AdminSettings
     show_domain_blocks
     show_domain_blocks_rationale
     noindex
+    norss
     require_invite_text
   ).freeze
 
@@ -48,6 +49,7 @@ class Form::AdminSettings
     trends
     trendable_by_default
     noindex
+    norss
     require_invite_text
   ).freeze
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -129,7 +129,7 @@ class User < ApplicationRecord
   has_many :session_activations, dependent: :destroy
 
   delegate :auto_play_gif, :default_sensitive, :unfollow_modal, :boost_modal, :delete_modal,
-           :reduce_motion, :system_font_ui, :noindex, :theme, :display_media,
+           :reduce_motion, :system_font_ui, :noindex, :norss, :theme, :display_media,
            :expand_spoilers, :default_language, :aggregate_reblogs, :show_application,
            :advanced_layout, :use_blurhash, :use_pending_items, :trends, :crop_images,
            :disable_swiping, :default_federation, :always_send_emails,

--- a/app/views/accounts/show.html.haml
+++ b/app/views/accounts/show.html.haml
@@ -5,7 +5,8 @@
   - if @account.user&.setting_noindex
     %meta{ name: 'robots', content: 'noindex, noarchive' }/
 
-  %link{ rel: 'alternate', type: 'application/rss+xml', href: @rss_url }/
+  - if !@account.user&.setting_norss
+    %link{ rel: 'alternate', type: 'application/rss+xml', href: @rss_url }/
   %link{ rel: 'alternate', type: 'application/activity+json', href: ActivityPub::TagManager.instance.uri_for(@account) }/
 
   - if @older_url

--- a/app/views/admin/settings/edit.html.haml
+++ b/app/views/admin/settings/edit.html.haml
@@ -91,6 +91,9 @@
     .fields-group
       = f.input :noindex, as: :boolean, wrapper: :with_label, label: t('admin.settings.default_noindex.title'), hint: t('admin.settings.default_noindex.desc_html')
 
+    .fields-group
+      = f.input :norss, as: :boolean, wrapper: :with_label, label: t('admin.settings.default_norss.title'), hint: t('admin.settings.default_norss.desc_html')
+
   %hr.spacer/
 
   .fields-group

--- a/app/views/settings/preferences/other/show.html.haml
+++ b/app/views/settings/preferences/other/show.html.haml
@@ -11,6 +11,9 @@
     = f.input :setting_noindex, as: :boolean, wrapper: :with_label
 
   .fields-group
+    = f.input :setting_norss, as: :boolean, wrapper: :with_label
+
+  .fields-group
     = f.input :setting_aggregate_reblogs, as: :boolean, wrapper: :with_label, recommended: true
 
   %h4= t 'preferences.posting_defaults'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -671,6 +671,9 @@ en:
       default_noindex:
         desc_html: Affects all users who have not changed this setting themselves
         title: Opt users out of search engine indexing by default
+      default_norss:
+        desc_html: Affects all users who have not changed this setting themselves
+        title: Opt users out of having an RSS feed of their public posts by default
       domain_blocks:
         all: To everyone
         disabled: To no one

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -170,6 +170,7 @@ en:
         setting_expand_spoilers: Always expand posts marked with content warnings
         setting_hide_network: Hide your social graph
         setting_noindex: Opt-out of search engine indexing
+        setting_norss: Opt-out of an RSS feed for your public posts
         setting_reduce_motion: Reduce motion in animations
         setting_show_application: Disclose application used to send posts
         setting_system_font_ui: Use system's default font

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -30,6 +30,7 @@ defaults: &defaults
   show_application: true
   system_font_ui: false
   noindex: false
+  norss: false
   theme: 'default'
   aggregate_reblogs: true
   advanced_layout: false


### PR DESCRIPTION
There is now a `norss` user preference for a user to opt out of having an RSS feed of their public posts. This operates on the exact same logic as the existing `noindex` for the search engine opt-out: the admin can check a box in Site Settings for a default setting for users. If a user has never touched their RSS opt-out setting then it is equal to whatever the default is. But individual users can override the default in their Preferences -> Other menu.

So a privacy-minded server admin could opt everyone out by default, but the overall default behavior is to have RSS feeds of public posts for everyone, which is the default Mastodon behavior anyway.

The `norss`, like `noindex`, is just a key on a pre-existing `settings` object that is a key-value store, so there doesn't even need to be a database migration for this!

If you are opted out of RSS, there will be no feed discovery link in your profile's HTML, and if you go to the RSS url where you would expect to find the RSS file, you will get an empty but valid RSS feed. It will have the account name but no content (I did this so that existing RSS readers won't complain if they are subscribing to a feed and then that person shuts theirs off -- it will just look like there is no content in the feed rather than throwing a 404).

Appearance in Administration --> Site Settings:

![image](https://user-images.githubusercontent.com/266454/205477114-c2e1daa2-306a-432e-81dc-e61539107549.png)

Appearance for individual users in Preferences --> Other:

![image](https://user-images.githubusercontent.com/266454/205477129-b893110d-0a32-49f3-84a1-d648c5049d48.png)

Fixes #1232