### PR TITLE
Fix #1236 Increase max length of UserInviteRequest.text from 420 to 5000

### DIFF
--- a/app/models/user_invite_request.rb
+++ b/app/models/user_invite_request.rb
@@ -13,5 +13,5 @@
 
 class UserInviteRequest < ApplicationRecord
   belongs_to :user, inverse_of: :invite_request
-  validates :text, presence: true, length: { maximum: 420 }
+  validates :text, presence: true, length: { maximum: 5000 }
 end


### PR DESCRIPTION
Fixes #1236 