### PR TITLE
Updating search engine opt-out language

### DIFF
--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -56,7 +56,7 @@ en:
         setting_display_media_hide_all: Always hide media
         setting_display_media_show_all: Always show media
         setting_hide_network: Who you follow and who follows you will be hidden on your profile
-        setting_noindex: Affects your public profile and post pages
+        setting_noindex: Affects your public profile and post pages. Public replies you make to other people may still be indexed on their pages. <a href="https://github.com/hometown-fork/hometown/issues/1234">See here for more information.</a>
         setting_show_application: The application you use to post will be displayed in the detailed view of your posts
         setting_use_blurhash: Gradients are based on the colors of the hidden visuals but obfuscate any details
         setting_use_pending_items: Hide timeline updates behind a click instead of automatically scrolling the feed
@@ -206,7 +206,7 @@ en:
         setting_display_media_show_all: Show all
         setting_expand_spoilers: Always expand posts marked with content warnings
         setting_hide_network: Hide your social graph
-        setting_noindex: Opt-out of search engine indexing
+        setting_noindex: Opt-out of search engine indexing for your profile page
         setting_norss: Opt-out of an RSS feed for your public posts
         setting_reduce_motion: Reduce motion in animations
         setting_show_application: Disclose application used to send posts

--- a/config/locales/simple_form.en_GB.yml
+++ b/config/locales/simple_form.en_GB.yml
@@ -31,7 +31,7 @@ en_GB:
         setting_display_media_hide_all: Always hide all media
         setting_display_media_show_all: Always show media marked as sensitive
         setting_hide_network: Who you follow and who follows you will not be shown on your profile
-        setting_noindex: Affects your public profile and status pages
+        setting_noindex: Affects your public profile and post pages. Public replies you make to other people may still be indexed on their pages. <a href="https://github.com/hometown-fork/hometown/issues/1234">See here for more information.</a>
         setting_show_application: The application you use to toot will be displayed in the detailed view of your toots
         username: Your username will be unique on %{domain}
         whole_word: When the keyword or phrase is alphanumeric only, it will only be applied if it matches the whole word
@@ -99,7 +99,7 @@ en_GB:
         setting_display_media_show_all: Show all
         setting_expand_spoilers: Always expand toots marked with content warnings
         setting_hide_network: Hide your network
-        setting_noindex: Opt-out of search engine indexing
+        setting_noindex: Opt-out of search engine indexing for your profile page
         setting_reduce_motion: Reduce motion in animations
         setting_show_application: Disclose application used to send toots
         setting_system_font_ui: Use system's default font


### PR DESCRIPTION
Fixes #1234 by adding language to the preferences page. It's only in English, unfortunately.