### PR TITLE
Bring back server privacy settings that were removed in v4.0.0

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -17,6 +17,8 @@ class AccountsController < ApplicationController
     respond_to do |format|
       format.html do
         expires_in 0, public: true unless user_signed_in?
+
+        @rss_url  = rss_url
       end
 
       format.rss do

--- a/app/controllers/admin/settings/hometown_controller.rb
+++ b/app/controllers/admin/settings/hometown_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Admin::Settings::HometownController < Admin::SettingsController
+  private
+
+  def after_update_redirect_path
+    admin_settings_hometown_path
+  end
+end

--- a/app/javascript/styles/macaron/diff.scss
+++ b/app/javascript/styles/macaron/diff.scss
@@ -450,6 +450,19 @@ body.admin {
 .admin-wrapper .content h4 {
   border-bottom: 1px solid #eeeeee;
 }
+.admin-wrapper {
+  .content {
+    &__heading {
+      &__tabs {
+        a {
+          &.selected {
+            color: $white;
+          }
+        }
+      }
+    }
+  }
+}
 
 .admin-wrapper .sidebar ul a.selected {
   background: $purple;

--- a/app/views/admin/settings/discovery/show.html.haml
+++ b/app/views/admin/settings/discovery/show.html.haml
@@ -26,6 +26,9 @@
   .fields-group
     = f.input :timeline_preview, as: :boolean, wrapper: :with_label
 
+  .fields-group
+    = f.input :noindex, as: :boolean, wrapper: :with_label, label: t('admin.settings.default_noindex.title'), hint: t('admin.settings.default_noindex.desc_html')
+
   %h4= t('admin.settings.discovery.publish_discovered_servers')
 
   .fields-group

--- a/app/views/admin/settings/discovery/show.html.haml
+++ b/app/views/admin/settings/discovery/show.html.haml
@@ -26,6 +26,11 @@
   .fields-group
     = f.input :timeline_preview, as: :boolean, wrapper: :with_label
 
+  %h4= t('admin.settings.discovery.publish_discovered_servers')
+
+  .fields-group
+    = f.input :peers_api_enabled, as: :boolean, wrapper: :with_label, recommended: :recommended
+
   %h4= t('admin.settings.discovery.follow_recommendations')
 
   .fields-group

--- a/app/views/admin/settings/hometown/show.html.haml
+++ b/app/views/admin/settings/hometown/show.html.haml
@@ -1,0 +1,22 @@
+- content_for :header_tags do
+  = javascript_pack_tag 'admin', async: true, crossorigin: 'anonymous'
+
+- content_for :page_title do
+  = t('admin.settings.hometown.title')
+
+- content_for :heading do
+  %h2= t('admin.settings.title')
+  = render partial: 'admin/settings/shared/links'
+
+= simple_form_for @admin_settings, url: admin_settings_hometown_path, html: { method: :patch } do |f|
+  = render 'shared/error_messages', object: @admin_settings
+
+  %p.lead= t('admin.settings.hometown.preamble')
+
+  %h4= t('admin.settings.hometown.privacy')
+
+  .fields-group
+    = f.input :norss, as: :boolean, wrapper: :with_label
+
+  .actions
+    = f.button :button, t('generic.save_changes'), type: :submit

--- a/app/views/admin/settings/shared/_links.html.haml
+++ b/app/views/admin/settings/shared/_links.html.haml
@@ -6,3 +6,4 @@
     - primary.item :discovery, safe_join([fa_icon('search fw'), t('admin.settings.discovery.title')]), admin_settings_discovery_path
     - primary.item :content_retention, safe_join([fa_icon('history fw'), t('admin.settings.content_retention.title')]), admin_settings_content_retention_path
     - primary.item :appearance, safe_join([fa_icon('desktop fw'), t('admin.settings.appearance.title')]), admin_settings_appearance_path
+    - primary.item :hometown, safe_join([fa_icon('home fw'), t('admin.settings.hometown.title')]), admin_settings_hometown_path

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -704,6 +704,9 @@ en:
       content_retention:
         preamble: Control how user-generated content is stored in Mastodon.
         title: Content retention
+      default_noindex:
+        desc_html: Affects all users who have not changed this setting themselves
+        title: Opt users out of search engine indexing by default
       discovery:
         follow_recommendations: Follow recommendations
         preamble: Surfacing interesting content is instrumental in onboarding new users who may not know anyone Mastodon. Control how various discovery features work on your server.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -709,6 +709,7 @@ en:
         preamble: Surfacing interesting content is instrumental in onboarding new users who may not know anyone Mastodon. Control how various discovery features work on your server.
         profile_directory: Profile directory
         public_timelines: Public timelines
+        publish_discovered_servers: Publish discovered servers
         title: Discovery
         trends: Trends
       domain_blocks:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -715,6 +715,10 @@ en:
         all: To everyone
         disabled: To no one
         users: To logged-in local users
+      hometown:
+        title: Hometown
+        preamble: These site-wide settings are provided to you by Hometown. As the server admin, you should think carefully about what you want each setting to be, since this will have an impact in shaping your community.
+        privacy: Privacy
       registrations:
         preamble: Control who can create an account on your server.
         title: Registrations

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -83,6 +83,7 @@ en:
         mascot: Overrides the illustration in the advanced web interface.
         media_cache_retention_period: Downloaded media files will be deleted after the specified number of days when set to a positive value, and re-downloaded on demand.
         norss: Affects all users who have not changed this setting themselves.
+        peers_api_enabled: A list of domain names this server has encountered in the fediverse. No data is included here about whether you federate with a given server, just that your server knows about it. This is used by services that collect statistics on federation in a general sense.
         profile_directory: The profile directory lists all users who have opted-in to be discoverable.
         require_invite_text: When sign-ups require manual approval, make the “Why do you want to join?” text input mandatory rather than optional
         site_contact_email: How people can reach you for legal or support inquiries.
@@ -243,6 +244,7 @@ en:
         media_cache_retention_period: Media cache retention period
         norss: Opt users out of having an RSS feed of their public posts by default
         profile_directory: Enable profile directory
+        peers_api_enabled: Publish list of discovered servers in the API
         registrations_mode: Who can sign-up
         require_invite_text: Require a reason to join
         show_domain_blocks: Show domain blocks

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -82,6 +82,7 @@ en:
         custom_css: You can apply custom styles on the web version of Mastodon.
         mascot: Overrides the illustration in the advanced web interface.
         media_cache_retention_period: Downloaded media files will be deleted after the specified number of days when set to a positive value, and re-downloaded on demand.
+        norss: Affects all users who have not changed this setting themselves.
         profile_directory: The profile directory lists all users who have opted-in to be discoverable.
         require_invite_text: When sign-ups require manual approval, make the “Why do you want to join?” text input mandatory rather than optional
         site_contact_email: How people can reach you for legal or support inquiries.
@@ -240,6 +241,7 @@ en:
         custom_css: Custom CSS
         mascot: Custom mascot (legacy)
         media_cache_retention_period: Media cache retention period
+        norss: Opt users out of having an RSS feed of their public posts by default
         profile_directory: Enable profile directory
         registrations_mode: Who can sign-up
         require_invite_text: Require a reason to join

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -271,6 +271,7 @@ Rails.application.routes.draw do
       resource :about, only: [:show, :update], controller: 'about'
       resource :appearance, only: [:show, :update], controller: 'appearance'
       resource :discovery, only: [:show, :update], controller: 'discovery'
+      resource :hometown, only: [:show, :update], controller: 'hometown'
     end
 
     resources :site_uploads, only: [:destroy]


### PR DESCRIPTION
This PR adds a "Hometown" tab to the "Server Settings" menu for administrators. I have placed our site-wide RSS default opt-in/opt-out setting here, and future Hometown-specific site-wide settings will go there too.

![image](https://user-images.githubusercontent.com/266454/209872955-02ccb819-9275-4d7e-ba87-b685ec598c41.png)

This PR also brings back the site-wide setting for whether users are default opted in to or out of search engine indexing (thanks @prplecake) and the site-wide setting for whether the list of discovered servers is available to the public via the API. Both options are under Server Settings -> Discovery now:

![image](https://user-images.githubusercontent.com/266454/209873103-f64d9eb2-481e-43af-9c03-bcafe5404edc.png)

Fixes #1211 