### PR TITLE
Fix paragraph formatting in the reply-to box

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -925,6 +925,16 @@
     }
   }
 
+  p {
+    margin-bottom: 1em;
+    white-space: pre-wrap;
+    unicode-bidi: plaintext;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
   a {
     color: $secondary-text-color;
     text-decoration: underline;


### PR DESCRIPTION
This CSS was accidentally deleted back when I was implementing `Article` support.

Now when you reply to something that has paragraph breaks, the paragraph breaks render correctly:

![image](https://user-images.githubusercontent.com/266454/209875411-00a9b0d8-703e-4e45-806f-89235a38c75c.png)

Fixes #1241