### PR TITLE
Adding a server setting for default federation

### DIFF
--- a/app/lib/settings/scoped_settings.rb
+++ b/app/lib/settings/scoped_settings.rb
@@ -6,6 +6,7 @@ module Settings
       theme
       noindex
       norss
+      default_federation
     ).freeze
 
     def initialize(object)

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -28,6 +28,7 @@ class Form::AdminSettings
     show_domain_blocks_rationale
     noindex
     norss
+    default_federation
     require_invite_text
     media_cache_retention_period
     content_cache_retention_period
@@ -50,6 +51,7 @@ class Form::AdminSettings
     trendable_by_default
     noindex
     norss
+    default_federation
     require_invite_text
   ).freeze
 

--- a/app/views/admin/settings/hometown/show.html.haml
+++ b/app/views/admin/settings/hometown/show.html.haml
@@ -18,5 +18,8 @@
   .fields-group
     = f.input :norss, as: :boolean, wrapper: :with_label
 
+  .fields-group
+    = f.input :default_federation, as: :boolean, wrapper: :with_label
+
   .actions
     = f.button :button, t('generic.save_changes'), type: :submit

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -80,6 +80,7 @@ en:
         closed_registrations_message: Displayed when sign-ups are closed
         content_cache_retention_period: Posts from other servers will be deleted after the specified number of days when set to a positive value. This may be irreversible.
         custom_css: You can apply custom styles on the web version of Mastodon.
+        default_federation: Affects all users who have not changed this setting themselves. Unchecking this means new users will post local-only by default unless they change it in their preferences.
         mascot: Overrides the illustration in the advanced web interface.
         media_cache_retention_period: Downloaded media files will be deleted after the specified number of days when set to a positive value, and re-downloaded on demand.
         norss: Affects all users who have not changed this setting themselves.
@@ -240,6 +241,7 @@ en:
         closed_registrations_message: Custom message when sign-ups are not available
         content_cache_retention_period: Content cache retention period
         custom_css: Custom CSS
+        default_federation: Set the default posting privacy for new users to federated
         mascot: Custom mascot (legacy)
         media_cache_retention_period: Media cache retention period
         norss: Opt users out of having an RSS feed of their public posts by default


### PR DESCRIPTION
There is now a toggle under Administration -> Server Settings -> Hometown that lets an admin make new accounts default to local-only privacy for posts. It does not affect current accounts.

![image](https://user-images.githubusercontent.com/266454/209882528-5edd4bd7-5002-4104-8058-f6e638f89453.png)

Fixes #704