### PR TITLE
Add command to remove avatar and header images of inactive remote acc…

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ require:
   - rubocop-rails
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
   NewCops: disable
   Exclude:
     - 'spec/**/*'


### PR DESCRIPTION
This cherry-picks [this pull request commit](https://github.com/mastodon/mastodon/pull/22149) into Hometown. It will be coming in a future Mastodon release but we will get it early. Basically it adds options to `tootctl media remove`:

>  Removes locally cached copies of media attachments (and optionally profile headers and
  avatars) from other servers. By default, only media attachements are removed. The --days  option specifies how old media attachments have to be before they are removed. In case of  avatars and headers, it specifies how old the last webfinger request and update to the user has to be before they are pruned. It defaults to 7 days. If --prune-profiles is specified, only avatars and headers are removed. If --remove-headers is specified, only headers are removed. If --include-follows is specified along with --prune-profiles or --remove-headers, all non-local profiles will be pruned irrespective of follow status. By default, only accounts
  that are not followed by or following anyone locally are pruned.

Relates to but does not fully address #1209 because there needs to be a web UI component, too.