### PR TITLE
yarn.lock: add hash so NixOS fetching works

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3306,7 +3306,7 @@ caniuse-api@^3.0.0:
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001400:
   version "1.0.30001414"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001414.tgz"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001414.tgz#5f1715e506e71860b4b07c50060ea6462217611e"
   integrity sha512-t55jfSaWjCdocnFdKQoO+d2ct9C59UZg4dY3OnUlSZ447r8pUtIKdp0hpAzrGFultmTC+Us+KpKi4GZl/LXlFg==
 
 chalk@^1.1.3:


### PR DESCRIPTION
NixOS uses the hashes in yarn.lock to fetch dependencies at build time; this dependency doesn't have a hash, so building Hometown on NixOS would fail. Adding a hash (calculated manually with curl + shasum) fixes the build on NixOS and doesn't change the behaviour otherwise.

This broke in #17902 upstream previously; this is a similar fix here.