### PR TITLE
Allow anonymous profile view

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -133,7 +133,7 @@ class Api::BaseController < ApplicationController
   end
 
   def disallow_unauthenticated_api_access?
-    ENV['DISALLOW_UNAUTHENTICATED_API_ACCESS'] == 'true' || Rails.configuration.x.whitelist_mode
+    (ENV['DISALLOW_UNAUTHENTICATED_API_ACCESS'] == 'true' || Rails.configuration.x.whitelist_mode) unless current_user
   end
 
   private

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -136,6 +136,15 @@ class Api::BaseController < ApplicationController
     (ENV['DISALLOW_UNAUTHENTICATED_API_ACCESS'] == 'true' || Rails.configuration.x.whitelist_mode) unless current_user
   end
 
+  def user_would_block_unauthenticated_api_access?(account)
+    # alternately account.locked? would also be a good candidate for this
+    disallow_unauthenticated_api_access? && account.user_prefers_noindex?
+  end
+
+  def user_blocks_unauthenticated_api_access
+    render json: { error: 'This user is only visible to authenticated users' }, status: 401
+  end
+
   private
 
   def respond_with_error(code)

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -133,7 +133,8 @@ class Api::BaseController < ApplicationController
   end
 
   def disallow_unauthenticated_api_access?
-    (ENV['DISALLOW_UNAUTHENTICATED_API_ACCESS'] == 'true' || Rails.configuration.x.whitelist_mode) unless current_user
+    return false if current_user
+    ENV['DISALLOW_UNAUTHENTICATED_API_ACCESS'] == 'true' || Rails.configuration.x.whitelist_mode
   end
 
   def user_would_block_unauthenticated_api_access?(account)

--- a/app/controllers/api/v1/accounts/featured_tags_controller.rb
+++ b/app/controllers/api/v1/accounts/featured_tags_controller.rb
@@ -21,6 +21,9 @@ class Api::V1::Accounts::FeaturedTagsController < Api::BaseController
   end
 
   def set_featured_tags
-    @featured_tags = @account.suspended? || disallow_unauthenticated_api_access? ? [] : @account.featured_tags
+    @featured_tags = if @account.suspended? || disallow_unauthenticated_api_access?
+      []
+    else
+      @account.featured_tags
   end
 end

--- a/app/controllers/api/v1/accounts/featured_tags_controller.rb
+++ b/app/controllers/api/v1/accounts/featured_tags_controller.rb
@@ -3,10 +3,14 @@
 class Api::V1::Accounts::FeaturedTagsController < Api::BaseController
   before_action :set_account
   before_action :set_featured_tags
+  skip_before_action :require_authenticated_user!, only: [:index]
 
   respond_to :json
 
   def index
+    if user_would_block_unauthenticated_api_access?(@account)
+      user_blocks_unauthenticated_api_access and return
+    end
     render json: @featured_tags, each_serializer: REST::FeaturedTagSerializer
   end
 
@@ -17,6 +21,6 @@ class Api::V1::Accounts::FeaturedTagsController < Api::BaseController
   end
 
   def set_featured_tags
-    @featured_tags = @account.suspended? ? [] : @account.featured_tags
+    @featured_tags = @account.suspended? || disallow_unauthenticated_api_access? ? [] : @account.featured_tags
   end
 end

--- a/app/controllers/api/v1/accounts/lookup_controller.rb
+++ b/app/controllers/api/v1/accounts/lookup_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V1::Accounts::LookupController < Api::BaseController
-  skip_before_action :require_authenticated_user!
+  skip_before_action :require_authenticated_user!, only: :show
   before_action -> { authorize_if_got_token! :read, :'read:accounts' }
   before_action :set_account
 

--- a/app/controllers/api/v1/accounts/lookup_controller.rb
+++ b/app/controllers/api/v1/accounts/lookup_controller.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 class Api::V1::Accounts::LookupController < Api::BaseController
+  skip_before_action :require_authenticated_user!
   before_action -> { authorize_if_got_token! :read, :'read:accounts' }
   before_action :set_account
 
   def show
+    if user_would_block_unauthenticated_api_access?(@account)
+      user_blocks_unauthenticated_api_access and return
+    end
     render json: @account, serializer: REST::AccountSerializer
   end
 

--- a/app/controllers/api/v1/accounts/statuses_controller.rb
+++ b/app/controllers/api/v1/accounts/statuses_controller.rb
@@ -22,7 +22,10 @@ class Api::V1::Accounts::StatusesController < Api::BaseController
   end
 
   def load_statuses
-    @account.suspended? || disallow_unauthenticated_api_access? ? [] : cached_account_statuses
+    if @account.suspended? || disallow_unauthenticated_api_access?
+      []
+    else
+      cached_account_statuses
   end
 
   def cached_account_statuses

--- a/app/controllers/api/v1/accounts/statuses_controller.rb
+++ b/app/controllers/api/v1/accounts/statuses_controller.rb
@@ -3,11 +3,15 @@
 class Api::V1::Accounts::StatusesController < Api::BaseController
   before_action -> { authorize_if_got_token! :read, :'read:statuses' }
   before_action :set_account
+  skip_before_action :require_authenticated_user!, only: [:index]
 
   after_action :insert_pagination_headers, unless: -> { truthy_param?(:pinned) }
 
   def index
     @statuses = load_statuses
+    if user_would_block_unauthenticated_api_access?(@account)
+      user_blocks_unauthenticated_api_access and return
+    end
     render json: @statuses, each_serializer: REST::StatusSerializer, relationships: StatusRelationshipsPresenter.new(@statuses, current_user&.account_id)
   end
 
@@ -18,7 +22,7 @@ class Api::V1::Accounts::StatusesController < Api::BaseController
   end
 
   def load_statuses
-    @account.suspended? ? [] : cached_account_statuses
+    @account.suspended? || disallow_unauthenticated_api_access? ? [] : cached_account_statuses
   end
 
   def cached_account_statuses

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -13,11 +13,14 @@ class Api::V1::AccountsController < Api::BaseController
   before_action :check_account_confirmation, except: [:create]
   before_action :check_enabled_registrations, only: [:create]
 
-  skip_before_action :require_authenticated_user!, only: :create
+  skip_before_action :require_authenticated_user!, only: [:create, :show]
 
   override_rate_limit_headers :follow, family: :follows
 
   def show
+    if user_would_block_unauthenticated_api_access?(@account)
+      user_blocks_unauthenticated_api_access and return
+    end
     render json: @account, serializer: REST::AccountSerializer
   end
 

--- a/app/controllers/api/v1/custom_emojis_controller.rb
+++ b/app/controllers/api/v1/custom_emojis_controller.rb
@@ -2,7 +2,7 @@
 
 class Api::V1::CustomEmojisController < Api::BaseController
   skip_before_action :set_cache_headers
-  skip_before_action :require_authenticated_user!
+  skip_before_action :require_authenticated_user!, only: :index
 
   def index
     expires_in 3.minutes, public: true

--- a/app/controllers/api/v1/custom_emojis_controller.rb
+++ b/app/controllers/api/v1/custom_emojis_controller.rb
@@ -2,6 +2,7 @@
 
 class Api::V1::CustomEmojisController < Api::BaseController
   skip_before_action :set_cache_headers
+  skip_before_action :require_authenticated_user!
 
   def index
     expires_in 3.minutes, public: true

--- a/app/javascript/mastodon/reducers/timelines.js
+++ b/app/javascript/mastodon/reducers/timelines.js
@@ -190,6 +190,10 @@ export default function timelines(state = initialState, action) {
   case TIMELINE_EXPAND_REQUEST:
     return state.update(action.timeline, initialTimeline, map => map.set('isLoading', true));
   case TIMELINE_EXPAND_FAIL:
+    if (action.error?.response?.status === 401) {
+      // don't loop continuously on 401 unauthenticated response
+      return state.update(action.timeline, initialTimeline, map => map.set('hasMore', false));
+    }
     return state.update(action.timeline, initialTimeline, map => map.set('isLoading', false));
   case TIMELINE_EXPAND_SUCCESS:
     return expandNormalizedTimeline(state, action.timeline, fromJS(action.statuses), action.next, action.partial, action.isLoadingRecent, action.usePendingItems);


### PR DESCRIPTION
This PR allows unauthenticated viewers to render a profile if it has not opted out of search engine indexing. Would resolve https://github.com/MSPSocial/projects/issues/4#issue-1581332535, which was unfortunately introduced by https://github.com/mastodon/mastodon/pull/19803 .

Considerations:
* This explicitly does not give access to any statuses (ie posts/notes/toots)
* This behavior depends on the search engine indexing opt-out for lack of a better existing pref.
* I considered using the followers-require-approval (the so-called "locked") preference, but the search engine preference felt closer to the spirit of the function, as the whole point of disabling unauthenticated API access is to avoid scrapers.

It would probably be better to put this into a new preference, but personally the whole spectrum of privacy preferences in the software should be represented by something more nuanced than a binary. It seems like a fine-grained privacy permissions system would be better here (with each category of data having selectors for audiences, eg: `only me`, `my followers`, `anybody on my instance`, `anybody on the fediverse`, `anybody on the internet`) but that's a huge project.

Hence this stopgap. (Cc: @lawremipsum, @t54r4n1)