### PR TITLE
Adds edit-history-modal style to account for the macaron theme

### DIFF
--- a/app/javascript/styles/macaron/diff.scss
+++ b/app/javascript/styles/macaron/diff.scss
@@ -543,7 +543,8 @@ body.admin {
 .report-modal,
 .embed-modal,
 .error-modal,
-.onboarding-modal {
+.onboarding-modal,
+.compare-history-modal {
   background: $ui-base-color;
 }
 


### PR DESCRIPTION
In the macaron theme, the modal that shows you a post's edit history shows up as dark text on a dark background. I added the missing declaration so that now it updates dynamically.

Before:
![before-theme-change](https://user-images.githubusercontent.com/61608357/231021054-41a13470-cde2-4f72-95f5-669ac4841233.png)

After:
![after-theme-change](https://user-images.githubusercontent.com/61608357/231021236-5207d623-4f07-43e2-9528-981909669e0b.png)

Details: v4.0.2+hometown-1.1.1