### PR TITLE
Add missing numeric value for "dislike" category

### DIFF
--- a/app/javascript/mastodon/features/notifications/components/report.js
+++ b/app/javascript/mastodon/features/notifications/components/report.js
@@ -11,6 +11,7 @@ const messages = defineMessages({
   other: { id: 'report_notification.categories.other', defaultMessage: 'Other' },
   spam: { id: 'report_notification.categories.spam', defaultMessage: 'Spam' },
   violation: { id: 'report_notification.categories.violation', defaultMessage: 'Rule violation' },
+  dislike: { id: 'report_notification.categories.dislike', defaultMessage: 'Dislike' },
 });
 
 export default @injectIntl

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -48,6 +48,7 @@ class Report < ApplicationRecord
     other: 0,
     spam: 1_000,
     violation: 2_000,
+    dislike: 3_000
   }
 
   def local?

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -48,7 +48,7 @@ class Report < ApplicationRecord
     other: 0,
     spam: 1_000,
     violation: 2_000,
-    dislike: 3_000
+    dislike: 3_000,
   }
 
   def local?


### PR DESCRIPTION
As created on upstream: https://github.com/mastodon/mastodon/pull/25833

Not sure if you wanna merge it and if this is the correct branch (according to the README, it should've been `hometown-dev`, which looks fairly outdated), but because it's such a small and still important fix, I've just submitted it here. ^^

Note: This is marked as a draft now. I got told that the "other" category does not create reports at all on Mastodon. I'm unsure whether you want that it's creating reports or not. If so, this PR should fix that feature, but **needs a recompile of the web assets**.

~~Note 2: as of right now, I'm not even sure whether it's a bug or if I just forgot to re-compile the web app when Mastodon dropped the reports for this type. I apologize for any inconvenience this might have caused so far.~~ Checked it again, it's required for the "I don't like this reports". Looks like Hometown creates reports for that.