### PR TITLE
Backport changes of Mastodon 4.1.11

### DIFF
--- a/app/chewy/accounts_index.rb
+++ b/app/chewy/accounts_index.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AccountsIndex < Chewy::Index
+  include DatetimeClampingConcern
+
   settings index: { refresh_interval: '30s' }, analysis: {
     analyzer: {
       content: {
@@ -38,6 +40,6 @@ class AccountsIndex < Chewy::Index
 
     field :following_count, type: 'long', value: ->(account) { account.following_count }
     field :followers_count, type: 'long', value: ->(account) { account.followers_count }
-    field :last_status_at, type: 'date', value: ->(account) { account.last_status_at || account.created_at }
+    field :last_status_at, type: 'date', value: ->(account) { clamp_date(account.last_status_at || account.created_at) }
   end
 end

--- a/app/chewy/concerns/datetime_clamping_concern.rb
+++ b/app/chewy/concerns/datetime_clamping_concern.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module DatetimeClampingConcern
+  extend ActiveSupport::Concern
+
+  MIN_ISO8601_DATETIME = '0000-01-01T00:00:00Z'.to_datetime.freeze
+  MAX_ISO8601_DATETIME = '9999-12-31T23:59:59Z'.to_datetime.freeze
+
+  class_methods do
+    def clamp_date(datetime)
+      datetime.clamp(MIN_ISO8601_DATETIME, MAX_ISO8601_DATETIME)
+    end
+  end
+end

--- a/app/chewy/tags_index.rb
+++ b/app/chewy/tags_index.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class TagsIndex < Chewy::Index
+  include DatetimeClampingConcern
+
   settings index: { refresh_interval: '30s' }, analysis: {
     analyzer: {
       content: {
@@ -36,6 +38,6 @@ class TagsIndex < Chewy::Index
 
     field :reviewed, type: 'boolean', value: ->(tag) { tag.reviewed? }
     field :usage, type: 'long', value: ->(tag, crutches) { tag.history.aggregate(crutches.time_period).accounts }
-    field :last_status_at, type: 'date', value: ->(tag) { tag.last_status_at || tag.created_at }
+    field :last_status_at, type: 'date', value: ->(tag) { clamp_date(tag.last_status_at || tag.created_at) }
   end
 end

--- a/app/lib/activitypub/linked_data_signature.rb
+++ b/app/lib/activitypub/linked_data_signature.rb
@@ -18,8 +18,8 @@ class ActivityPub::LinkedDataSignature
 
     return unless type == 'RsaSignature2017'
 
-    creator   = ActivityPub::TagManager.instance.uri_to_actor(creator_uri)
-    creator ||= ActivityPub::FetchRemoteKeyService.new.call(creator_uri, id: false)
+    creator = ActivityPub::TagManager.instance.uri_to_actor(creator_uri)
+    creator = ActivityPub::FetchRemoteKeyService.new.call(creator_uri, id: false) if creator&.public_key.blank?
 
     return if creator.nil?
 
@@ -27,9 +27,9 @@ class ActivityPub::LinkedDataSignature
     document_hash  = hash(@json.without('signature'))
     to_be_verified = options_hash + document_hash
 
-    if creator.keypair.public_key.verify(OpenSSL::Digest.new('SHA256'), Base64.decode64(signature), to_be_verified)
-      creator
-    end
+    creator if creator.keypair.public_key.verify(OpenSSL::Digest.new('SHA256'), Base64.decode64(signature), to_be_verified)
+  rescue OpenSSL::PKey::RSAError
+    false
   end
 
   def sign!(creator, sign_with: nil)

--- a/app/lib/activitypub/parser/status_parser.rb
+++ b/app/lib/activitypub/parser/status_parser.rb
@@ -53,7 +53,8 @@ class ActivityPub::Parser::StatusParser
   end
 
   def created_at
-    @object['published']&.to_datetime
+    datetime = @object['published']&.to_datetime
+    datetime if datetime.present? && (0..9999).cover?(datetime.year)
   rescue ArgumentError
     nil
   end

--- a/app/models/concerns/attachmentable.rb
+++ b/app/models/concerns/attachmentable.rb
@@ -52,9 +52,13 @@ module Attachmentable
     return if attachment.blank? || !/image.*/.match?(attachment.content_type) || attachment.queued_for_write[:original].blank?
 
     width, height = FastImage.size(attachment.queued_for_write[:original].path)
-    matrix_limit  = attachment.content_type == 'image/gif' ? GIF_MATRIX_LIMIT : MAX_MATRIX_LIMIT
+    return unless width.present? && height.present?
 
-    raise Mastodon::DimensionsValidationError, "#{width}x#{height} images are not supported" if width.present? && height.present? && (width * height > matrix_limit)
+    if attachment.content_type == 'image/gif' && width * height > GIF_MATRIX_LIMIT
+      raise Mastodon::DimensionsValidationError, "#{width}x#{height} GIF files are not supported"
+    elsif width * height > MAX_MATRIX_LIMIT
+      raise Mastodon::DimensionsValidationError, "#{width}x#{height} images are not supported"
+    end
   end
 
   def appropriate_extension(attachment)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -29,7 +29,7 @@ class Tag < ApplicationRecord
   HASHTAG_SEPARATORS = "_\u00B7\u200c"
   HASHTAG_NAME_PAT = "([[:word:]_][[:word:]#{HASHTAG_SEPARATORS}]*[[:alpha:]#{HASHTAG_SEPARATORS}][[:word:]#{HASHTAG_SEPARATORS}]*[[:word:]_])|([[:word:]_]*[[:alpha:]][[:word:]_]*)"
 
-  HASHTAG_RE = /(?:^|[^\/\)\w])#(#{HASHTAG_NAME_PAT})/i
+  HASHTAG_RE = %r{(?<![=/)\w])#(#{HASHTAG_NAME_PAT})}i
   HASHTAG_NAME_RE = /\A(#{HASHTAG_NAME_PAT})\z/i
   HASHTAG_INVALID_CHARS_RE = /[^[:alnum:]#{HASHTAG_SEPARATORS}]/
 

--- a/app/models/trends/statuses.rb
+++ b/app/models/trends/statuses.rb
@@ -91,7 +91,7 @@ class Trends::Statuses < Trends::Base
   private
 
   def eligible?(status)
-    status.public_visibility? && status.account.discoverable? && !status.account.silenced? && status.spoiler_text.blank? && !status.sensitive? && !status.reply? && valid_locale?(status.language)
+    status.public_visibility? && status.account.discoverable? && !status.account.silenced? && !status.account.sensitized? && status.spoiler_text.blank? && !status.sensitive? && !status.reply? && valid_locale?(status.language)
   end
 
   def calculate_scores(statuses, at_time)

--- a/app/serializers/rest/featured_tag_serializer.rb
+++ b/app/serializers/rest/featured_tag_serializer.rb
@@ -10,7 +10,9 @@ class REST::FeaturedTagSerializer < ActiveModel::Serializer
   end
 
   def url
-    short_account_tag_url(object.account, object.tag)
+    # The path is hardcoded because we have to deal with both local and
+    # remote users, which are different routes
+    account_with_domain_url(object.account, "tagged/#{object.tag.to_param}")
   end
 
   def name

--- a/app/services/follow_service.rb
+++ b/app/services/follow_service.rb
@@ -71,7 +71,7 @@ class FollowService < BaseService
     if @target_account.local?
       LocalNotificationWorker.perform_async(@target_account.id, follow_request.id, follow_request.class.name, 'follow_request')
     elsif @target_account.activitypub?
-      ActivityPub::DeliveryWorker.perform_async(build_json(follow_request), @source_account.id, @target_account.inbox_url)
+      ActivityPub::DeliveryWorker.perform_async(build_json(follow_request), @source_account.id, @target_account.inbox_url, { 'bypass_availability' => true })
     end
 
     follow_request

--- a/app/workers/activitypub/delivery_worker.rb
+++ b/app/workers/activitypub/delivery_worker.rb
@@ -13,9 +13,10 @@ class ActivityPub::DeliveryWorker
   HEADERS = { 'Content-Type' => 'application/activity+json' }.freeze
 
   def perform(json, source_account_id, inbox_url, options = {})
-    return unless DeliveryFailureTracker.available?(inbox_url)
-
     @options        = options.with_indifferent_access
+
+    return unless @options[:bypass_availability] || DeliveryFailureTracker.available?(inbox_url)
+
     @json           = json
     @source_account = Account.find(source_account_id)
     @inbox_url      = inbox_url

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -3,7 +3,11 @@
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
 def host_to_url(str)
-  "http#{Rails.configuration.x.use_https ? 's' : ''}://#{str.split('/').first}" if str.present?
+  return if str.blank?
+
+  uri = Addressable::URI.parse("http#{Rails.configuration.x.use_https ? 's' : ''}://#{str}")
+  uri.path += '/' unless uri.path.blank? || uri.path.end_with?('/')
+  uri.to_s
 end
 
 base_host = Rails.configuration.x.web_domain

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -125,7 +125,7 @@ Rails.application.routes.draw do
     get '/@:account_username/:id/embed', to: 'statuses#embed', as: :embed_short_account_status
   end
 
-  get '/@:username_with_domain/(*any)', to: 'home#index', constraints: { username_with_domain: /([^\/])+?/ }, format: false
+  get '/@:username_with_domain/(*any)', to: 'home#index', constraints: { username_with_domain: %r{([^/])+?} }, as: :account_with_domain, format: false
   get '/settings', to: redirect('/settings/profile')
 
   namespace :settings do

--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -13,7 +13,7 @@ module Mastodon
     end
 
     def patch
-      10
+      11
     end
 
     def flags

--- a/spec/lib/activitypub/linked_data_signature_spec.rb
+++ b/spec/lib/activitypub/linked_data_signature_spec.rb
@@ -36,6 +36,40 @@ RSpec.describe ActivityPub::LinkedDataSignature do
       end
     end
 
+    context 'when local account record is missing a public key' do
+      let(:raw_signature) do
+        {
+          'creator' => 'http://example.com/alice',
+          'created' => '2017-09-23T20:21:34Z',
+        }
+      end
+
+      let(:signature) { raw_signature.merge('type' => 'RsaSignature2017', 'signatureValue' => sign(sender, raw_signature, raw_json)) }
+
+      let(:service_stub) { instance_double(ActivityPub::FetchRemoteKeyService) }
+
+      before do
+        # Ensure signature is computed with the old key
+        signature
+
+        # Unset key
+        old_key = sender.public_key
+        sender.update!(private_key: '', public_key: '')
+
+        allow(ActivityPub::FetchRemoteKeyService).to receive(:new).and_return(service_stub)
+
+        allow(service_stub).to receive(:call).with('http://example.com/alice', id: false) do
+          sender.update!(public_key: old_key)
+          sender
+        end
+      end
+
+      it 'fetches key and returns creator' do
+        expect(subject.verify_actor!).to eq sender
+        expect(service_stub).to have_received(:call).with('http://example.com/alice', id: false).once
+      end
+    end
+
     context 'when signature is missing' do
       let(:signature) { nil }
 

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -30,40 +30,52 @@ RSpec.describe Tag, type: :model do
       expect(subject.match('https://en.wikipedia.org/wiki/Ghostbusters_(song)#Lawsuit')).to be_nil
     end
 
+    it 'does not match URLs with hashtag-like anchors after a numeral' do
+      expect(subject.match('https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111895#c4')).to be_nil
+    end
+
+    it 'does not match URLs with hashtag-like anchors after an empty query parameter' do
+      expect(subject.match('https://en.wikipedia.org/wiki/Ghostbusters_(song)?foo=#Lawsuit')).to be_nil
+    end
+
     it 'matches ﻿#ａｅｓｔｈｅｔｉｃ' do
-      expect(subject.match('﻿this is #ａｅｓｔｈｅｔｉｃ').to_s).to eq ' #ａｅｓｔｈｅｔｉｃ'
+      expect(subject.match('﻿this is #ａｅｓｔｈｅｔｉｃ').to_s).to eq '#ａｅｓｔｈｅｔｉｃ'
     end
 
     it 'matches digits at the start' do
-      expect(subject.match('hello #3d').to_s).to eq ' #3d'
+      expect(subject.match('hello #3d').to_s).to eq '#3d'
     end
 
     it 'matches digits in the middle' do
-      expect(subject.match('hello #l33ts35k').to_s).to eq ' #l33ts35k'
+      expect(subject.match('hello #l33ts35k').to_s).to eq '#l33ts35k'
     end
 
     it 'matches digits at the end' do
-      expect(subject.match('hello #world2016').to_s).to eq ' #world2016'
+      expect(subject.match('hello #world2016').to_s).to eq '#world2016'
     end
 
     it 'matches underscores at the beginning' do
-      expect(subject.match('hello #_test').to_s).to eq ' #_test'
+      expect(subject.match('hello #_test').to_s).to eq '#_test'
     end
 
     it 'matches underscores at the end' do
-      expect(subject.match('hello #test_').to_s).to eq ' #test_'
+      expect(subject.match('hello #test_').to_s).to eq '#test_'
     end
 
     it 'matches underscores in the middle' do
-      expect(subject.match('hello #one_two_three').to_s).to eq ' #one_two_three'
+      expect(subject.match('hello #one_two_three').to_s).to eq '#one_two_three'
     end
 
     it 'matches middle dots' do
-      expect(subject.match('hello #one·two·three').to_s).to eq ' #one·two·three'
+      expect(subject.match('hello #one·two·three').to_s).to eq '#one·two·three'
+    end
+
+    it 'matches ・unicode in ぼっち・ざ・ろっく correctly' do
+      expect(subject.match('testing #ぼっち・ざ・ろっく').to_s).to eq '#ぼっち・ざ・ろっく'
     end
 
     it 'matches ZWNJ' do
-      expect(subject.match('just add #نرم‌افزار and').to_s).to eq ' #نرم‌افزار'
+      expect(subject.match('just add #نرم‌افزار and').to_s).to eq '#نرم‌افزار'
     end
 
     it 'does not match middle dots at the start' do
@@ -71,7 +83,7 @@ RSpec.describe Tag, type: :model do
     end
 
     it 'does not match middle dots at the end' do
-      expect(subject.match('hello #one·two·three·').to_s).to eq ' #one·two·three'
+      expect(subject.match('hello #one·two·three·').to_s).to eq '#one·two·three'
     end
 
     it 'does not match purely-numeric hashtags' do

--- a/spec/requests/api/v1/accounts/featured_tags_spec.rb
+++ b/spec/requests/api/v1/accounts/featured_tags_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'account featured tags API' do
+  let(:user)     { Fabricate(:user) }
+  let(:token)    { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
+  let(:scopes)   { 'read:accounts' }
+  let(:headers)  { { 'Authorization' => "Bearer #{token.token}" } }
+  let(:account)  { Fabricate(:account) }
+
+  describe 'GET /api/v1/accounts/:id/featured_tags' do
+    subject do
+      get "/api/v1/accounts/#{account.id}/featured_tags", headers: headers
+    end
+
+    before do
+      account.featured_tags.create!(name: 'foo')
+      account.featured_tags.create!(name: 'bar')
+    end
+
+    it 'returns the expected tags', :aggregate_failures do
+      subject
+
+      expect(response).to have_http_status(200)
+      expect(body_as_json).to contain_exactly(a_hash_including({
+        name: 'bar',
+        url: "https://cb6e6126.ngrok.io/@#{account.username}/tagged/bar",
+      }), a_hash_including({
+        name: 'foo',
+        url: "https://cb6e6126.ngrok.io/@#{account.username}/tagged/foo",
+      }))
+    end
+
+    context 'when the account is remote' do
+      it 'returns the expected tags', :aggregate_failures do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(body_as_json).to contain_exactly(a_hash_including({
+          name: 'bar',
+          url: "https://cb6e6126.ngrok.io/@#{account.pretty_acct}/tagged/bar",
+        }), a_hash_including({
+          name: 'foo',
+          url: "https://cb6e6126.ngrok.io/@#{account.pretty_acct}/tagged/foo",
+        }))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Those changes were computed by calculating the diff (git diff v4.1.10...v4.1.11) and then using a three-way merge to apply those changes to the v4.0.10+hometown-1.1.1 tag.

I am not sure about the correct branch to merge into, feel free to update this.

I also haven't tested the changes yet, but since there were no conflicts and they are not touching the local-only parts, it *should* be safe to merge this.

**edit**: deployed it on queer.group, so far it seems to be working fine. :3 

The [changelog for v4.1.11](https://github.com/mastodon/mastodon/releases/tag/v4.1.11) shows all of the changes.