### PR TITLE
Minor fixes for "Fairy Floss" theme in 1.1.1

### DIFF
--- a/app/javascript/styles/fairy-floss/diff.scss
+++ b/app/javascript/styles/fairy-floss/diff.scss
@@ -381,22 +381,6 @@ a.mention,
   background: $purple1;
 }
 
-.dropdown-menu,
-.dropdown-menu__item a {
-  background: $purple4;
-}
-
-.dropdown-menu__item a {
-  &:hover,
-  &:focus {
-    background: $purple2;
-  }
-}
-
-.dropdown-menu__separator {
-  border-bottom: 1px solid darken($purple4, 4%);
-}
-
 .button.logo-button.button--destructive:active,
 .button.logo-button.button--destructive:focus,
 .button.logo-button.button--destructive:hover {

--- a/app/javascript/styles/fairy-floss/diff.scss
+++ b/app/javascript/styles/fairy-floss/diff.scss
@@ -214,6 +214,15 @@ body.admin {
 
 // link previews
 
+.status-card {
+  background: $purple5;
+
+  &:hover,
+  &:focus {
+    background: darken($purple5, 4%);
+  }
+}
+
 .status-card.compact {
   border-color: darken($purple5, 8%);
   background: $purple5;
@@ -221,15 +230,6 @@ body.admin {
 
 .status-card__image {
   background: $purple3;
-}
-
-.status-card__content {
-  background: $purple5;
-
-  &:hover,
-  &:focus {
-    background: darken($purple5, 4%);
-  }
 }
 
 .notification__filter-bar button.active,


### PR DESCRIPTION
My instance was updated to 1.1.1 recently, and I noticed the background color does not fill the whole card for links without big preview images on top when using the fairy-floss theme:

![image](https://github.com/hometown-fork/hometown/assets/525780/c184f3d7-58cc-4593-937b-7a167e53a0be)

Similarly, there's some background code missing to the right when the link content (title / preview) don't stretch the card content to fill the link horizontally:

![image](https://github.com/hometown-fork/hometown/assets/525780/d908f94f-1dce-446b-b795-25be4421c0fa)

This diff should fix that. There's some remaining styling for `.status-card.compact`, but I don't know where that's used.

The second commit fixes some issues with the dropdown that appears when clicking the "…" button on the bottom left of a post:

**Before**
![image](https://github.com/hometown-fork/hometown/assets/525780/5ef58f6a-f90a-4320-b122-55418b51227d)

**After**
![image](https://github.com/hometown-fork/hometown/assets/525780/fb4f89cf-817f-478b-a02c-a6d15e66bb49)

My apologies if these changes should be made upstream somewhere, but I didn't find another repo for the theme.