### PR TITLE
Remove "post published" popup

### DIFF
--- a/app/javascript/mastodon/actions/compose.js
+++ b/app/javascript/mastodon/actions/compose.js
@@ -245,13 +245,6 @@ export function submitCompose(routerHistory) {
         insertIfOnline('public');
         insertIfOnline(`account:${response.data.account.id}`);
       }
-
-      dispatch(showAlert({
-        message: statusId === null ? messages.published : messages.saved,
-        action: messages.open,
-        dismissAfter: 10000,
-        onClick: () => routerHistory.push(`/@${response.data.account.username}/${response.data.id}`),
-      }));
     }).catch(function (error) {
       dispatch(submitComposeFail(error));
     });


### PR DESCRIPTION
This seems to have been fairly unpopular with Hometown users, and I know a few instances have removed it already. Might as well bring the patch to remove it into Hometown itself.

refs https://github.com/friendcamp/mastodon/commit/94381897390be107668a12476d53358fd2c123ec

@dariusk Is this the right branch? It looks like the current detault branch has a commit history that's prior to the most recent release.