### PR TITLE
sidekiq: disable update checker

### DIFF
--- a/app/models/software_update.rb
+++ b/app/models/software_update.rb
@@ -24,7 +24,7 @@ class SoftwareUpdate < ApplicationRecord
 
   class << self
     def check_enabled?
-      ENV['UPDATE_CHECK_URL'] != ''
+      false
     end
 
     def pending_to_a

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -62,6 +62,7 @@
       interval: 30 minutes
       class: Scheduler::SoftwareUpdateCheckScheduler
       queue: scheduler
+      enabled: false
     auto_close_registrations_scheduler:
       interval: 1 hour
       class: Scheduler::AutoCloseRegistrationsScheduler


### PR DESCRIPTION
This is configured to look for upstream Mastodon updates, so it isn't actually doing anything useful for Hometown admins. Eventually it can be turned back on if there's a Hometown-specific API that returns the appropriate versions, but in the meantime this feature is misleading.

Looking at the sidekiq-scheduler docs, I think this should be enough to turn it off: https://github.com/sidekiq-scheduler/sidekiq-scheduler?tab=readme-ov-file#schedule-configuration

I also disabled it in the place where upstream Mastodon configures the feature to be on or off: https://docs.joinmastodon.org/admin/upgrading/#automated_checks

Fixes #1367.