### PR TITLE
Add back underlines to links in posts

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -848,7 +848,7 @@ body > [data-popper-placement] {
 
   a {
     color: $secondary-text-color;
-    text-decoration: none;
+    text-decoration: underline;
     unicode-bidi: isolate;
 
     &:hover {


### PR DESCRIPTION
As mentioned [in Hometown's README](https://github.com/hometown-fork/hometown#better-accessibility-defaults), links in posts are meant to be underlined by default for better accessibility. However, this default was overridden in one of the stylesheets so [every Hometown instance I know of](https://github.com/hometown-fork/hometown/wiki/Hometown-servers) (with the exception of weirder.earth) does not have any underlined links in posts as of right now. This pull request restores those underlines.

Before (feed view):
<img width="579" height="183" alt="The post link has no underline." src="https://github.com/user-attachments/assets/7dc3d5bb-dca4-4dcd-9148-98c343a68316" />

After (feed view):
<img width="579" height="183" alt="The post link has an underline now." src="https://github.com/user-attachments/assets/5b892a89-f252-4ccb-925a-76d410fa426e" />

Before (expanded view):
<img width="582" height="223" alt="The post link has no underline." src="https://github.com/user-attachments/assets/8e41e0e7-7fca-43f5-a5d5-bf0147d3a9cd" />

After (expanded view):
<img width="582" height="223" alt="The post link has an underline now." src="https://github.com/user-attachments/assets/5c209ec4-690a-4e74-a90e-dfc4eca44867" />