### PR TITLE
notifications: fix notification for "dislike" report

### DIFF
--- a/app/javascript/mastodon/features/notifications_v2/components/notification_admin_report.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_admin_report.tsx
@@ -11,6 +11,10 @@ import { useAppSelector } from 'mastodon/store';
 
 // This needs to be kept in sync with app/models/report.rb
 const messages = defineMessages({
+  dislike: {
+    id: 'report_notification.categories.dislike_sentence',
+    defaultMessage: 'dislike',
+  },
   other: {
     id: 'report_notification.categories.other_sentence',
     defaultMessage: 'other',

--- a/app/javascript/mastodon/locales/en-GB.json
+++ b/app/javascript/mastodon/locales/en-GB.json
@@ -830,6 +830,8 @@
   "report.unfollow": "Unfollow @{name}",
   "report.unfollow_explanation": "You are following this account. To not see their posts in your home feed anymore, unfollow them.",
   "report_notification.attached_statuses": "{count, plural, one {{count} post} other {{count} posts}} attached",
+  "report_notification.categories.dislike": "I don't like it",
+  "report_notification.categories.dislike_sentence": "content they disliked",
   "report_notification.categories.legal": "Legal",
   "report_notification.categories.legal_sentence": "illegal content",
   "report_notification.categories.other": "Other",

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -835,6 +835,8 @@
   "report.unfollow": "Unfollow @{name}",
   "report.unfollow_explanation": "You are following this account. To not see their posts in your home feed anymore, unfollow them.",
   "report_notification.attached_statuses": "{count, plural, one {{count} post} other {{count} posts}} attached",
+  "report_notification.categories.dislike": "I don't like it",
+  "report_notification.categories.dislike_sentence": "content they disliked",
   "report_notification.categories.legal": "Legal",
   "report_notification.categories.legal_sentence": "illegal content",
   "report_notification.categories.other": "Other",

--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -29,7 +29,7 @@ module Mastodon
     end
 
     def hometown_version
-      'hometown-1.2.0'
+      'hometown-1.2.1'
     end
 
     def to_a


### PR DESCRIPTION
We were missing the UI strings for displaying a user report about the "dislike" notification type, which would cause the notifications page to fail to render properly if there was a recent report in the "dislike" category. We had a few of the other strings necessary but not the ones for the notification pane, and this didn't come up in my testing.

Here's what the notification looks like now:

<img width="750" height="96" alt="image" src="https://github.com/user-attachments/assets/0dba1584-ec03-4a9d-950c-73a274c30974" />

I also tested in non-English languages to make sure the fallback string will display correctly. It's not perfect, but it's about as good as our other Hometown-specific strings in non-English locales so I think that's fine.

<img width="606" height="92" alt="image" src="https://github.com/user-attachments/assets/f6b203ef-f649-478f-abe6-12b0c8f0eabb" />

I also went ahead and bumped the Hometown version to 1.2.1; I figure we can get a quick release with this fix out.

Fixes #1388.