### PR TITLE
styles(fairy-floss): fix meta text on detailed view

### DIFF
--- a/app/javascript/styles/fairy-floss/diff.scss
+++ b/app/javascript/styles/fairy-floss/diff.scss
@@ -312,6 +312,10 @@ body.admin {
   border-bottom: 1px solid lighten($purple3, 8%);
 }
 
+.detailed-status__meta {
+  color: $purple4;
+}
+
 .focusable:focus {
   background: $purplescrollbar;
 }

--- a/app/javascript/styles/fairy-floss/diff.scss
+++ b/app/javascript/styles/fairy-floss/diff.scss
@@ -704,6 +704,21 @@ a.mention,
   font-weight: 900;
 }
 
+.dropdown-menu__item {
+  color: $black;
+
+  a,
+  button {
+    &:focus,
+    &:hover,
+    &:active {
+      &:not(:disabled, [aria-disabled='true']) {
+        color: $white;
+      }
+    }
+  }
+}
+
 .privacy-dropdown__option,
 .visibility-dropdown__option {
   &:focus,


### PR DESCRIPTION
Reported to me on the server I run. It looks like I'd missed testing this specific view in fairy-floss.

Before:

<img width="514" height="150" alt="image" src="https://github.com/user-attachments/assets/68a1546b-dafa-429a-8d00-642e59aeb97e" />

After:

<img width="506" height="138" alt="image" src="https://github.com/user-attachments/assets/360454ba-ba2e-4794-8357-513cbd96ee63" />
