### PR TITLE
Build Hometown instead of Mastodon in `docker-compose.yml`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,9 +80,9 @@ services:
 
   streaming:
     # You can uncomment the following lines if you want to not use the prebuilt image, for example if you have local code changes
-    # build:
-    #   dockerfile: ./streaming/Dockerfile
-    #   context: .
+    build:
+      dockerfile: ./streaming/Dockerfile
+      context: .
     image: ghcr.io/mastodon/mastodon-streaming:v4.5.7
     restart: always
     env_file: .env.production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
 
   web:
     # You can uncomment the following line if you want to not use the prebuilt image, for example if you have local code changes
-    # build: .
+    build: .
     image: ghcr.io/mastodon/mastodon:v4.5.7
     restart: always
     env_file: .env.production


### PR DESCRIPTION
The `docker-compose.yml` was ported directly from Mastodon, and over there they prefer using pre-built images. Unfortunately, that means all the customization brought in by Hometown is lost and `docker compose build` is a no-op. The solution is to uncomment one line in that file.