### PR TITLE
README.md: Delete mention of quote posting as an upcoming feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,6 @@ Mastodon has a feature called "quote tweeting" that lets you embed what someone 
 
 <img width="600" src="http://tinysubversions.com/pics/quote-tweet.png" alt="An example of a quote tweet from Twitter.">
 
-> Hometown doesn't support quoting articles yet... but it will.
-
 ## Better list management
 
 If Hometown is going to be a universal reader, you're going to need better control over organizing your feeds than mainline Mastodon provides.


### PR DESCRIPTION
AFAICT quote posting should have been implemented in the most recent releases of Hometown following Mastodon >4.5.6. Hope I'm not getting ahead of myself here :)