### PR TITLE
Remove Mastodon-specific checks for container builds

### DIFF
--- a/.github/workflows/build-releases.yml
+++ b/.github/workflows/build-releases.yml
@@ -20,64 +20,27 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check latest stable
-        shell: bash
-        id: check
-        run: |
-          ref="${GITHUB_REF#refs/tags/}"
-
-          if [[ "$ref" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?$ ]]; then
-            current="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
-          else
-            echo "tag $ref is not semver"
-            echo "is_latest_stable=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          latest=$(git for-each-ref --format='%(refname:short)' "refs/remotes/origin/stable-*.*" \
-            | sed -E 's#^origin/stable-##' \
-            | sort -Vr \
-            | head -n1)
-
-          if [[ "$current" == "$latest" ]]; then
-            echo "is_latest_stable=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "is_latest_stable=false" >> "$GITHUB_OUTPUT"
-          fi
-
   build-image:
-    needs: check-latest-stable
     uses: ./.github/workflows/build-container-image.yml
     with:
       file_to_build: Dockerfile
       push_to_images: |
-        tootsuite/mastodon
-        ghcr.io/mastodon/mastodon
+        ghcr.io/hometown-fork/hometown
       # Do not use cache when building releases, so apt update is always ran and the release always contain the latest packages
       cache: false
-      # Only tag with latest when ran against the latest stable branch
-      # This needs to be updated after each minor version release
-      flavor: |
-        latest=${{ needs.check-latest-stable.outputs.latest }}
       tags: |
         type=pep440,pattern={{raw}}
         type=pep440,pattern=v{{major}}.{{minor}}
     secrets: inherit
 
   build-image-streaming:
-    needs: check-latest-stable
     uses: ./.github/workflows/build-container-image.yml
     with:
       file_to_build: streaming/Dockerfile
       push_to_images: |
-        tootsuite/mastodon-streaming
-        ghcr.io/mastodon/mastodon-streaming
+        ghcr.io/hometown-fork/hometown-streaming
       # Do not use cache when building releases, so apt update is always ran and the release always contain the latest packages
       cache: false
-      # Only tag with latest when ran against the latest stable branch
-      # This needs to be updated after each minor version release
-      flavor: |
-        latest=${{ needs.check-latest-stable.outputs.latest }}
       tags: |
         type=pep440,pattern={{raw}}
         type=pep440,pattern=v{{major}}.{{minor}}


### PR DESCRIPTION
This will try to build against the (currently not existing) container images on the GitHub Container Registry. Yet, it's YAML engineering and therefore completely untested.

Yet, I'm not sure whether Hometown ever had proper container builds working. Right now, I can't find any of them. There are some [hometown images on the Docker Hub](https://hub.docker.com/search?q=hometown), but none of them is official. Therefore, the container builds have quite a low priority right now, but it would be nice to support them nonetheless, I guess.