### PR TITLE
Revert "Fix Hometown patch in lib/mastodon/version.rb"

### DIFF
--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -29,7 +29,7 @@ module Mastodon
     end
 
     def hometown_version
-      'hometown-1.2.2'
+      'hometown-1.2.1'
     end
 
     def to_a


### PR DESCRIPTION
We decided not to bump this version since there were no Hometown-specific changes this release.

This reverts commit f7b28baa8f6a8b0b75fa8fa3c849ed0fad357379.