### PR TITLE
Fix missing %{title} substitutions

### DIFF
--- a/app/helpers/instance_helper.rb
+++ b/app/helpers/instance_helper.rb
@@ -10,7 +10,7 @@ module InstanceHelper
   end
 
   def description_for_sign_up(invite = nil)
-    safe_join([description_prefix(invite), I18n.t('auth.description.suffix')], ' ')
+    safe_join([description_prefix(invite), I18n.t('auth.description.suffix', title: Setting.site_title)], ' ')
   end
 
   def instance_presenter
@@ -35,7 +35,7 @@ module InstanceHelper
     if invite.present?
       I18n.t('auth.description.prefix_invited_by_user', name: invite.user.account.username, title: Setting.site_title)
     else
-      I18n.t('auth.description.prefix_sign_up')
+      I18n.t('auth.description.prefix_sign_up', title: Setting.site_title)
     end
   end
 end

--- a/app/serializers/web/notification_serializer.rb
+++ b/app/serializers/web/notification_serializer.rb
@@ -29,7 +29,7 @@ class Web::NotificationSerializer < ActiveModel::Serializer
   end
 
   def title
-    I18n.t("notification_mailer.#{object.type}.subject", name: object.from_account.display_name.presence || object.from_account.username)
+    I18n.t("notification_mailer.#{object.type}.subject", name: object.from_account.display_name.presence || object.from_account.username, title: Setting.site_title)
   end
 
   def body

--- a/app/views/auth/registrations/new.html.haml
+++ b/app/views/auth/registrations/new.html.haml
@@ -8,7 +8,7 @@
   = render 'auth/shared/progress', stage: 'details'
 
   %h1.title= t('auth.sign_up.title', domain: site_hostname)
-  %p.lead= t('auth.sign_up.preamble')
+  %p.lead= t('auth.sign_up.preamble', title: Setting.site_title)
 
   = render 'shared/error_messages', object: resource
 

--- a/spec/system/admin/reset_spec.rb
+++ b/spec/system/admin/reset_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Admin::Reset' do
   end
 
   def submit_reset
-    click_on I18n.t('admin.accounts.reset_password')
+    click_on I18n.t('admin.accounts.reset_password', title: Setting.site_title)
   end
 
   def password_change_subject


### PR DESCRIPTION
I hope these are all cases, but I doubt it. I wish there'd be some kind of default variables, so we could override it globally, but I haven't found a way to do that. This fixes #1398.

## Discussion: Ditch the `%{title}` replacement completely?

Furthermore, I'm not sure whether we should stick to the upstream localisation and use "Mastodon" everywhere. For example, the sign-up page now reads like this on queer.group:

> Let's get you set up on queer.group.
> With an account on this queer and comfy cuddle group
> server, you'll be able to follow any other person on the
> Fediverse, regardless of where their account is hosted.

Yet, it's another one of those things that set Hometown apart from Mastodon. In the upstream code, everything is just hardcoded to "Mastodon", without any kind of personal touch. However, it could make our life easier for adapting upstream changes, I guess.

What's your opinion on this, @dariusk @mistydemeo?